### PR TITLE
Fix background overlay in instructor home

### DIFF
--- a/code/instructorhome.php
+++ b/code/instructorhome.php
@@ -229,7 +229,7 @@
       </div>
     </div>
   </nav>
-  <div class="page-header header-filter" data-parallax="true" style="background-image: url('./assets/img/profile_city.jpg')">
+  <div class="page-header header-filter clear-filter" data-parallax="true" style="background-image: url('./assets/img/profile_city.jpg')">
     <div class="container">
       <div class="row ">
       </div>


### PR DESCRIPTION
## Summary
- remove black overlay from instructor home background image

## Testing
- `php -l code/instructorhome.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684738015068832ea67029e1d2530203