### PR TITLE
Fix Manage Quizzes header visibility

### DIFF
--- a/code/manage_quizzes.php
+++ b/code/manage_quizzes.php
@@ -396,7 +396,7 @@ $conn->close();
 
     <div class="main-container">
         <div class="page-header header-filter" style="background-image: url('./assets/img/bg2.jpg'); background-size: cover; background-position: top center;">
-            <div class="container" style="padding-top: 15vh;">
+            <div class="container" style="padding-top: 20vh;">
                 <div class="row">
                     <div class="col-md-12 ml-auto mr-auto">
                         <div class="card card-login">


### PR DESCRIPTION
## Summary
- adjust padding for Manage Quizzes page so card title is below navbar

## Testing
- `php -l code/manage_quizzes.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847b25002d0832e890d52e16faad385