### PR TITLE
Fix Manage Quizzes header hidden behind navbar

### DIFF
--- a/code/manage_quizzes.php
+++ b/code/manage_quizzes.php
@@ -310,6 +310,7 @@ $conn->close();
         }
         .page-header {
             margin-top: 60px;
+            padding-top: 90px; /* Ensure content sits below fixed navbar */
             min-height: calc(100vh - 60px);
             position: relative;
         }


### PR DESCRIPTION
## Summary
- adjust `.page-header` padding so heading is visible on Manage Quizzes page

## Testing
- `php -l code/manage_quizzes.php`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847b66671d0832eb849fa87650a9b62