### PR TITLE
Fix Set Quiz heading visibility

### DIFF
--- a/code/quizconfig.php
+++ b/code/quizconfig.php
@@ -856,8 +856,8 @@ function saveSelectedQuestions() {
     .page-header {
       min-height: auto !important;
       height: auto !important;
-      margin: 0 !important;
-      padding: 20px 0 !important;
+      margin: 60px 0 0 0 !important;
+      padding: 90px 0 20px 0 !important;
       background-image: none !important;
       background-color: #f5f5f5 !important;
     }


### PR DESCRIPTION
## Summary
- fix heading overlap with navbar in **Set Quiz** page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6847b8037c30832eadece02cfa262763