### PR TITLE
Fix navbar spacing on set quiz page

### DIFF
--- a/code/quizconfig.php
+++ b/code/quizconfig.php
@@ -839,7 +839,7 @@ function saveSelectedQuestions() {
     /* Existing Styles */
     body {
       overflow-x: hidden;
-      padding-top: 50px;
+      padding-top: 70px;
       background-color: #f5f5f5;
     }
     .navbar {


### PR DESCRIPTION
## Summary
- increase top padding on the set quiz page so the fixed navbar isn't hidden

## Testing
- `php -l code/quizconfig.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b92948b0832ebf7fa83c4201b5fa