### PR TITLE
Add dark mode toggle

### DIFF
--- a/code/add_class.php
+++ b/code/add_class.php
@@ -63,6 +63,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
          .header-nav a { margin: 0 10px; text-decoration: none; color: #007bff; }
          .header-nav a:hover { text-decoration: underline; }
     </style>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 <body>
     <div class="container">
@@ -97,5 +98,6 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.3/dist/umd/popper.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html> 

--- a/code/assets/css/dark-mode.css
+++ b/code/assets/css/dark-mode.css
@@ -1,0 +1,36 @@
+body.dark-mode {
+  background-color: #121212;
+  color: #e0e0e0;
+}
+body.dark-mode a {
+  color: #90caf9;
+}
+body.dark-mode .navbar {
+  background-color: #333 !important;
+}
+body.dark-mode .navbar .nav-link,
+body.dark-mode .navbar-brand {
+  color: #fff !important;
+}
+body.dark-mode .card {
+  background-color: #1e1e1e;
+  color: #e0e0e0;
+}
+body.dark-mode .table {
+  color: #e0e0e0;
+}
+body.dark-mode .form-control {
+  background-color: #424242;
+  color: #fff;
+  border-color: #666;
+}
+body.dark-mode .dropdown-menu {
+  background-color: #1e1e1e;
+  color: #e0e0e0;
+}
+body.dark-mode .btn.btn-primary {
+  background-color: #1a73e8;
+}
+body.dark-mode .btn {
+  color: #fff;
+}

--- a/code/assets/js/dark-mode.js
+++ b/code/assets/js/dark-mode.js
@@ -1,0 +1,32 @@
+function initDarkMode(){
+  if(!document.getElementById('dark-mode-style')){
+    const link=document.createElement('link');
+    link.rel='stylesheet';
+    link.href='./assets/css/dark-mode.css';
+    link.id='dark-mode-style';
+    document.head.appendChild(link);
+  }
+  const nav=document.querySelector('.navbar .navbar-nav');
+  if(nav && !document.getElementById('darkModeToggle')){
+    const li=document.createElement('li');
+    li.className='nav-item d-flex align-items-center';
+    li.innerHTML='<div class="form-check form-switch mb-0">'+
+                 '<input class="form-check-input" type="checkbox" id="darkModeToggle">'+
+                 '</div>';
+    nav.appendChild(li);
+  }
+  const toggle=document.getElementById('darkModeToggle');
+  if(!toggle) return;
+  function apply(d){
+    if(d){document.body.classList.add('dark-mode');toggle.checked=true;}
+    else{document.body.classList.remove('dark-mode');toggle.checked=false;}
+  }
+  toggle.addEventListener('change',function(){
+    const en=toggle.checked;
+    localStorage.setItem('darkMode',en?'on':'off');
+    apply(en);
+  });
+  const saved=localStorage.getItem('darkMode');
+  apply(saved==='on');
+}
+document.addEventListener('DOMContentLoaded',initDarkMode);

--- a/code/calculate_marks.php
+++ b/code/calculate_marks.php
@@ -153,6 +153,7 @@ $conn->close(); // Close connection here before outputting HTML
         .message-success { color: #155724; background-color: #d4edda; border-color: #c3e6cb; }
         .message-error { color: #721c24; background-color: #f8d7da; border-color: #f5c6cb; }
     </style>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 <body>
     <div class="container">
@@ -165,5 +166,6 @@ $conn->close(); // Close connection here before outputting HTML
             <a href="<?php echo htmlspecialchars($_SESSION['instructor_results_page_url']); ?>" class="btn btn-info">Back to Results</a>
         <?php endif; ?>
     </div>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html> 

--- a/code/edit_class.php
+++ b/code/edit_class.php
@@ -95,6 +95,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['update_class']) && $cl
          .header-nav a { margin: 0 10px; text-decoration: none; color: #007bff; }
          .header-nav a:hover { text-decoration: underline; }
     </style>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 <body>
     <div class="container">
@@ -132,5 +133,6 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['update_class']) && $cl
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.3/dist/umd/popper.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html> 

--- a/code/edit_quiz.php
+++ b/code/edit_quiz.php
@@ -535,6 +535,7 @@ $conn->close();
         return true;
     }
   </script>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 <body class="login-page sidebar-collapse">
   <nav class="navbar fixed-top navbar-expand-lg">
@@ -1035,5 +1036,6 @@ $conn->close();
       }
     });
   </script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html> 

--- a/code/index.php
+++ b/code/index.php
@@ -222,6 +222,7 @@ if (isset($_SESSION['error'])) {
             }
         }
     </style>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 
 <body class="landing-page sidebar-collapse">
@@ -278,5 +279,6 @@ if (isset($_SESSION['error'])) {
             once: true
         });
     </script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html>

--- a/code/instructorhome.php
+++ b/code/instructorhome.php
@@ -160,6 +160,7 @@
         }
     }
   </style>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 
 <body class="landing-page sidebar-collapse">
@@ -271,5 +272,6 @@
       }
     });
   </script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html>

--- a/code/instructorlogin.php
+++ b/code/instructorlogin.php
@@ -237,6 +237,7 @@
             }
         }
     </style>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 
 <body class="login-page">
@@ -295,5 +296,6 @@
     <script src="./assets/js/core/bootstrap-material-design.min.js" type="text/javascript"></script>
     <script src="./assets/js/plugins/moment.min.js"></script>
     <script src="./assets/js/material-kit.js?v=2.0.4" type="text/javascript"></script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html>

--- a/code/manage_classes_subjects.php
+++ b/code/manage_classes_subjects.php
@@ -685,6 +685,7 @@ $stmt->close();
         .delete-btn { color: #dc3545; cursor: pointer; }
         .delete-btn:hover { color: #c82333; }
     </style>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 <body class="landing-page sidebar-collapse">
     <nav class="navbar fixed-top navbar-expand-lg">
@@ -1294,5 +1295,6 @@ $stmt->close();
     <script src="./assets/js/core/bootstrap-material-design.min.js" type="text/javascript"></script>
     <script src="./assets/js/plugins/moment.min.js"></script>
     <script src="./assets/js/material-kit.js?v=2.0.4" type="text/javascript"></script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html> 

--- a/code/manage_instructors.php
+++ b/code/manage_instructors.php
@@ -211,6 +211,7 @@ $conn->close();
             padding: 12px 20px;
         }
     </style>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 <body class="landing-page sidebar-collapse">
     <nav class="navbar fixed-top navbar-expand-lg">
@@ -348,5 +349,6 @@ $conn->close();
     <script src="./assets/js/core/bootstrap-material-design.min.js" type="text/javascript"></script>
     <script src="./assets/js/plugins/moment.min.js"></script>
     <script src="./assets/js/material-kit.js?v=2.0.4" type="text/javascript"></script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html> 

--- a/code/manage_notifications.php
+++ b/code/manage_notifications.php
@@ -155,6 +155,7 @@
       display: block;
     }
   </style>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 
 <body class="landing-page sidebar-collapse">
@@ -435,5 +436,6 @@
       });
     });
   </script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html> 

--- a/code/manage_quizzes.php
+++ b/code/manage_quizzes.php
@@ -324,6 +324,7 @@ $conn->close();
             position: relative;
         }
     </style>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 <body class="landing-page sidebar-collapse">
     <nav class="navbar fixed-top navbar-expand-lg">
@@ -551,5 +552,6 @@ $conn->close();
             });
         });
     </script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html> 

--- a/code/manage_students.php
+++ b/code/manage_students.php
@@ -539,6 +539,7 @@ $conn->close();
             margin-top: 10px;
         }
     </style>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 <body class="landing-page sidebar-collapse">
     <nav class="navbar fixed-top navbar-expand-lg">
@@ -1279,5 +1280,6 @@ $conn->close();
             });
         });
     </script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html> 

--- a/code/my_profile.php
+++ b/code/my_profile.php
@@ -166,6 +166,7 @@ $conn->close();
             margin-top: 5px;
         }
     </style>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 <body class="landing-page sidebar-collapse">
     <nav class="navbar fixed-top navbar-expand-lg">
@@ -319,5 +320,6 @@ $conn->close();
     <script src="./assets/js/core/bootstrap-material-design.min.js" type="text/javascript"></script>
     <script src="./assets/js/plugins/moment.min.js"></script>
     <script src="./assets/js/material-kit.js?v=2.0.4" type="text/javascript"></script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html> 

--- a/code/my_results.php
+++ b/code/my_results.php
@@ -82,6 +82,7 @@ $results = $stmt->get_result();
             margin: 20px 0;
         }
     </style>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 <body>
     <div class="container mt-4">
@@ -163,5 +164,6 @@ $results = $stmt->get_result();
     <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
     <!-- Bootstrap JS -->
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html> 

--- a/code/questionfeed.php
+++ b/code/questionfeed.php
@@ -1348,6 +1348,7 @@ function getChapters($conn, $class_id, $subject_id) {
       }
     }
   </style>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 <body class="landing-page sidebar-collapse">
   <nav class="navbar fixed-top navbar-expand-lg">
@@ -2151,5 +2152,6 @@ function getChapters($conn, $class_id, $subject_id) {
       }
     });
   </script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html>

--- a/code/quizconfig.php
+++ b/code/quizconfig.php
@@ -166,6 +166,7 @@ function getAvailableQuestionsCount($conn, $chapter_ids) {
     return $counts;
 }
 
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 // Add this JavaScript function before </head>
 echo "<script>
 function updateAvailableQuestions() {
@@ -1080,6 +1081,7 @@ function saveSelectedQuestions() {
         document.getElementById("total").innerHTML = ta+tb+tc+td+te+tf;
     }
   </script>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 
 <body class="landing-page sidebar-collapse">
@@ -2026,5 +2028,6 @@ function saveSelectedQuestions() {
       });
     });
   </script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html>

--- a/code/quizhome.php
+++ b/code/quizhome.php
@@ -113,6 +113,7 @@ try {
             }
         }
     </style>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 <body class="landing-page sidebar-collapse">
     <!-- Navbar -->
@@ -282,5 +283,6 @@ try {
     <script src="./assets/js/plugins/bootstrap-datetimepicker.js" type="text/javascript"></script>
     <script src="./assets/js/plugins/nouislider.min.js" type="text/javascript"></script>
     <script src="./assets/js/material-kit.js?v=2.0.4" type="text/javascript"></script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html>

--- a/code/quizpage.php
+++ b/code/quizpage.php
@@ -762,6 +762,7 @@ try {
         }
     };
     </script>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 <body>
     <div class="wrapper">
@@ -934,5 +935,6 @@ try {
             once: true
         });
     </script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html>

--- a/code/studenthome.php
+++ b/code/studenthome.php
@@ -191,6 +191,7 @@
       white-space: nowrap;
     }
   </style>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 
 <body class="landing-page sidebar-collapse">
@@ -350,5 +351,6 @@
       }
     });
   </script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html>

--- a/code/studentlogin.php
+++ b/code/studentlogin.php
@@ -250,6 +250,7 @@ $conn->close();
             }
         }
     </style>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 
 <body class="login-page">
@@ -308,5 +309,6 @@ $conn->close();
     <script src="./assets/js/core/bootstrap-material-design.min.js" type="text/javascript"></script>
     <script src="./assets/js/plugins/moment.min.js"></script>
     <script src="./assets/js/material-kit.js?v=2.0.4" type="text/javascript"></script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html>

--- a/code/studentregister.php
+++ b/code/studentregister.php
@@ -29,6 +29,7 @@
       }     
   }
   </script>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 
 <body class="login-page sidebar-collapse">
@@ -252,5 +253,6 @@
   <script src="./assets/js/plugins/nouislider.min.js" type="text/javascript"></script>
   <script src="./assets/js/plugins/jquery.sharrre.js" type="text/javascript"></script>
   <script src="./assets/js/material-kit.js?v=2.0.4" type="text/javascript"></script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html>

--- a/code/view_questions.php
+++ b/code/view_questions.php
@@ -479,6 +479,7 @@
       margin-top: 20px; 
     }
   </style>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 
 <body class="landing-page sidebar-collapse">
@@ -849,5 +850,6 @@
       }
     });
   </script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html> 

--- a/code/view_quiz_results.php
+++ b/code/view_quiz_results.php
@@ -306,6 +306,7 @@ $conn->close();
             margin-bottom: 30px;
         }
     </style>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 <body class="landing-page sidebar-collapse">
     <nav class="navbar fixed-top navbar-expand-lg">
@@ -421,5 +422,6 @@ $conn->close();
     <script src="./assets/js/plugins/bootstrap-datetimepicker.js" type="text/javascript"></script>
     <script src="./assets/js/plugins/nouislider.min.js" type="text/javascript"></script>
     <script src="./assets/js/material-kit.js?v=2.0.4" type="text/javascript"></script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html> 

--- a/code/view_student_attempt.php
+++ b/code/view_student_attempt.php
@@ -377,6 +377,7 @@ $conn->close();
             margin-bottom: 20px;
         }
     </style>
+<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 <body class="landing-page sidebar-collapse">
     <nav class="navbar fixed-top navbar-expand-lg">
@@ -677,5 +678,6 @@ $conn->close();
     <script src="./assets/js/plugins/bootstrap-datetimepicker.js" type="text/javascript"></script>
     <script src="./assets/js/plugins/nouislider.min.js" type="text/javascript"></script>
     <script src="./assets/js/material-kit.js?v=2.0.4" type="text/javascript"></script>
+<script src="./assets/js/dark-mode.js"></script>
 </body>
 </html> 


### PR DESCRIPTION
## Summary
- add universal dark-mode styles
- support remembering dark mode across pages
- include slider switch to every navbar via script

## Testing
- `php` not installed; lint skipped

------
https://chatgpt.com/codex/tasks/task_e_6847bd225110832e9d3986f57e94c86b