### PR TITLE
Fix dark mode initialization

### DIFF
--- a/code/assets/js/dark-mode.js
+++ b/code/assets/js/dark-mode.js
@@ -29,4 +29,8 @@ function initDarkMode(){
   const saved=localStorage.getItem('darkMode');
   apply(saved==='on');
 }
-document.addEventListener('DOMContentLoaded',initDarkMode);
+if(document.readyState==='loading'){
+  document.addEventListener('DOMContentLoaded',initDarkMode);
+}else{
+  initDarkMode();
+}


### PR DESCRIPTION
## Summary
- ensure dark-mode toggle script runs even if loaded after DOMContentLoaded

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6847c1798ba8832e8147496a9942cf67