### PR TITLE
Fix dark mode toggle placement

### DIFF
--- a/code/assets/js/dark-mode.js
+++ b/code/assets/js/dark-mode.js
@@ -6,14 +6,25 @@ function initDarkMode(){
     link.id='dark-mode-style';
     document.head.appendChild(link);
   }
-  const nav=document.querySelector('.navbar .navbar-nav');
-  if(nav && !document.getElementById('darkModeToggle')){
-    const li=document.createElement('li');
-    li.className='nav-item d-flex align-items-center';
-    li.innerHTML='<div class="form-check form-switch mb-0">'+
-                 '<input class="form-check-input" type="checkbox" id="darkModeToggle">'+
-                 '</div>';
-    nav.appendChild(li);
+  const navList=document.querySelector('.navbar .navbar-nav');
+  const navContainer=document.querySelector('.navbar .container');
+  if(!document.getElementById('darkModeToggle')){
+    if(navList){
+      const li=document.createElement('li');
+      li.className='nav-item d-flex align-items-center';
+      li.innerHTML='<div class="form-check form-switch mb-0">'+
+                   '<input class="form-check-input" type="checkbox" id="darkModeToggle">'+
+                   '</div>';
+      navList.appendChild(li);
+    } else if(navContainer){
+      const div=document.createElement('div');
+      div.className='d-flex align-items-center ml-auto';
+      div.style.marginLeft='auto';
+      div.innerHTML='<div class="form-check form-switch mb-0">'+
+                    '<input class="form-check-input" type="checkbox" id="darkModeToggle">'+
+                    '</div>';
+      navContainer.appendChild(div);
+    }
   }
   const toggle=document.getElementById('darkModeToggle');
   if(!toggle) return;


### PR DESCRIPTION
## Summary
- ensure dark mode toggle is appended even when navbar menu collapses

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y php-cli`
- `find code -name "*.php" -print0 | xargs -0 -n1 php -l` *(fails: PHP parse error)*

------
https://chatgpt.com/codex/tasks/task_e_6847c62e62ac832eba0a0f44e3793f5c