### PR TITLE
Fix dark mode toggle visibility

### DIFF
--- a/code/assets/js/dark-mode.js
+++ b/code/assets/js/dark-mode.js
@@ -12,16 +12,22 @@ function initDarkMode(){
     if(navList){
       const li=document.createElement('li');
       li.className='nav-item d-flex align-items-center';
-      li.innerHTML='<div class="form-check form-switch mb-0">'+
-                   '<input class="form-check-input position-static" type="checkbox" id="darkModeToggle">'+
+      li.innerHTML='<div class="togglebutton mb-0">'+
+                   '  <label class="m-0">'+
+                   '    <input type="checkbox" id="darkModeToggle">'+
+                   '    <span class="toggle"></span>'+
+                   '  </label>'+
                    '</div>';
       navList.appendChild(li);
     } else if(navContainer){
       const div=document.createElement('div');
       div.className='d-flex align-items-center ml-auto';
       div.style.marginLeft='auto';
-      div.innerHTML='<div class="form-check form-switch mb-0">'+
-                    '<input class="form-check-input position-static" type="checkbox" id="darkModeToggle">'+
+      div.innerHTML='<div class="togglebutton mb-0">'+
+                    '  <label class="m-0">'+
+                    '    <input type="checkbox" id="darkModeToggle">'+
+                    '    <span class="toggle"></span>'+
+                    '  </label>'+
                     '</div>';
       navContainer.appendChild(div);
     }

--- a/code/edit_quiz.php
+++ b/code/edit_quiz.php
@@ -603,9 +603,12 @@ $conn->close();
             </a>
           </li>
           <li class="nav-item d-flex align-items-center">
-            <div class="form-check form-switch mb-0">
-              <input class="form-check-input position-static" type="checkbox" id="darkModeToggle">
-            </div>
+            <div class="togglebutton mb-0">
+                <label class="m-0">
+                  <input type="checkbox" id="darkModeToggle">
+                  <span class="toggle"></span>
+                </label>
+              </div>
           </li>
         </ul>
       </div>      

--- a/code/instructorhome.php
+++ b/code/instructorhome.php
@@ -234,9 +234,12 @@
             </a>
           </li>
           <li class="nav-item d-flex align-items-center">
-            <div class="form-check form-switch mb-0">
-              <input class="form-check-input position-static" type="checkbox" id="darkModeToggle">
-            </div>
+            <div class="togglebutton mb-0">
+                <label class="m-0">
+                  <input type="checkbox" id="darkModeToggle">
+                  <span class="toggle"></span>
+                </label>
+              </div>
           </li>
         </ul>
       </div>

--- a/code/manage_classes_subjects.php
+++ b/code/manage_classes_subjects.php
@@ -753,9 +753,12 @@ $stmt->close();
                         </a>
                     </li>
           <li class="nav-item d-flex align-items-center">
-            <div class="form-check form-switch mb-0">
-              <input class="form-check-input position-static" type="checkbox" id="darkModeToggle">
-            </div>
+            <div class="togglebutton mb-0">
+                <label class="m-0">
+                  <input type="checkbox" id="darkModeToggle">
+                  <span class="toggle"></span>
+                </label>
+              </div>
           </li>
                 </ul>
             </div>

--- a/code/manage_instructors.php
+++ b/code/manage_instructors.php
@@ -279,9 +279,12 @@ $conn->close();
                         </a>
                     </li>
           <li class="nav-item d-flex align-items-center">
-            <div class="form-check form-switch mb-0">
-              <input class="form-check-input position-static" type="checkbox" id="darkModeToggle">
-            </div>
+            <div class="togglebutton mb-0">
+                <label class="m-0">
+                  <input type="checkbox" id="darkModeToggle">
+                  <span class="toggle"></span>
+                </label>
+              </div>
           </li>
                 </ul>
             </div>

--- a/code/manage_notifications.php
+++ b/code/manage_notifications.php
@@ -229,9 +229,12 @@
             </a>
           </li>
           <li class="nav-item d-flex align-items-center">
-            <div class="form-check form-switch mb-0">
-              <input class="form-check-input position-static" type="checkbox" id="darkModeToggle">
-            </div>
+            <div class="togglebutton mb-0">
+                <label class="m-0">
+                  <input type="checkbox" id="darkModeToggle">
+                  <span class="toggle"></span>
+                </label>
+              </div>
           </li>
         </ul>
       </div>

--- a/code/manage_quizzes.php
+++ b/code/manage_quizzes.php
@@ -392,9 +392,12 @@ $conn->close();
                         </a>
                     </li>
           <li class="nav-item d-flex align-items-center">
-            <div class="form-check form-switch mb-0">
-              <input class="form-check-input position-static" type="checkbox" id="darkModeToggle">
-            </div>
+            <div class="togglebutton mb-0">
+                <label class="m-0">
+                  <input type="checkbox" id="darkModeToggle">
+                  <span class="toggle"></span>
+                </label>
+              </div>
           </li>
                 </ul>
             </div>

--- a/code/manage_students.php
+++ b/code/manage_students.php
@@ -607,9 +607,12 @@ $conn->close();
                         </a>
                     </li>
           <li class="nav-item d-flex align-items-center">
-            <div class="form-check form-switch mb-0">
-              <input class="form-check-input position-static" type="checkbox" id="darkModeToggle">
-            </div>
+            <div class="togglebutton mb-0">
+                <label class="m-0">
+                  <input type="checkbox" id="darkModeToggle">
+                  <span class="toggle"></span>
+                </label>
+              </div>
           </li>
                 </ul>
             </div>

--- a/code/my_profile.php
+++ b/code/my_profile.php
@@ -233,9 +233,12 @@ $conn->close();
                         </a>
                     </li>
           <li class="nav-item d-flex align-items-center">
-            <div class="form-check form-switch mb-0">
-              <input class="form-check-input position-static" type="checkbox" id="darkModeToggle">
-            </div>
+            <div class="togglebutton mb-0">
+                <label class="m-0">
+                  <input type="checkbox" id="darkModeToggle">
+                  <span class="toggle"></span>
+                </label>
+              </div>
           </li>
                 </ul>
             </div>

--- a/code/questionfeed.php
+++ b/code/questionfeed.php
@@ -1416,9 +1416,12 @@ function getChapters($conn, $class_id, $subject_id) {
             </a>
           </li>
           <li class="nav-item d-flex align-items-center">
-            <div class="form-check form-switch mb-0">
-              <input class="form-check-input position-static" type="checkbox" id="darkModeToggle">
-            </div>
+            <div class="togglebutton mb-0">
+                <label class="m-0">
+                  <input type="checkbox" id="darkModeToggle">
+                  <span class="toggle"></span>
+                </label>
+              </div>
           </li>
         </ul>
       </div>

--- a/code/quizconfig.php
+++ b/code/quizconfig.php
@@ -1150,9 +1150,12 @@ function saveSelectedQuestions() {
             </a>
           </li>
           <li class="nav-item d-flex align-items-center">
-            <div class="form-check form-switch mb-0">
-              <input class="form-check-input position-static" type="checkbox" id="darkModeToggle">
-            </div>
+            <div class="togglebutton mb-0">
+                <label class="m-0">
+                  <input type="checkbox" id="darkModeToggle">
+                  <span class="toggle"></span>
+                </label>
+              </div>
           </li>
         </ul>
       </div>

--- a/code/studenthome.php
+++ b/code/studenthome.php
@@ -242,9 +242,12 @@
             </a>
           </li>          
           <li class="nav-item d-flex align-items-center">
-            <div class="form-check form-switch mb-0">
-              <input class="form-check-input position-static" type="checkbox" id="darkModeToggle">
-            </div>
+            <div class="togglebutton mb-0">
+                <label class="m-0">
+                  <input type="checkbox" id="darkModeToggle">
+                  <span class="toggle"></span>
+                </label>
+              </div>
           </li>
         </ul>
       </div>

--- a/code/view_questions.php
+++ b/code/view_questions.php
@@ -548,9 +548,12 @@
             </a>
           </li>
           <li class="nav-item d-flex align-items-center">
-            <div class="form-check form-switch mb-0">
-              <input class="form-check-input position-static" type="checkbox" id="darkModeToggle">
-            </div>
+            <div class="togglebutton mb-0">
+                <label class="m-0">
+                  <input type="checkbox" id="darkModeToggle">
+                  <span class="toggle"></span>
+                </label>
+              </div>
           </li>
         </ul>
       </div>

--- a/code/view_quiz_results.php
+++ b/code/view_quiz_results.php
@@ -374,9 +374,12 @@ $conn->close();
                         </a>
                     </li>
           <li class="nav-item d-flex align-items-center">
-            <div class="form-check form-switch mb-0">
-              <input class="form-check-input position-static" type="checkbox" id="darkModeToggle">
-            </div>
+            <div class="togglebutton mb-0">
+                <label class="m-0">
+                  <input type="checkbox" id="darkModeToggle">
+                  <span class="toggle"></span>
+                </label>
+              </div>
           </li>
                 </ul>
             </div>

--- a/code/view_student_attempt.php
+++ b/code/view_student_attempt.php
@@ -445,9 +445,12 @@ $conn->close();
                         </a>
                     </li>
           <li class="nav-item d-flex align-items-center">
-            <div class="form-check form-switch mb-0">
-              <input class="form-check-input position-static" type="checkbox" id="darkModeToggle">
-            </div>
+            <div class="togglebutton mb-0">
+                <label class="m-0">
+                  <input type="checkbox" id="darkModeToggle">
+                  <span class="toggle"></span>
+                </label>
+              </div>
           </li>
                 </ul>
             </div>


### PR DESCRIPTION
## Summary
- rework markup for dark mode toggle to use Material Kit switches
- update dark-mode.js to inject the new toggle markup

## Testing
- `php -l <file>` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847cd1a6da0832e9759489092b91be8