### PR TITLE
Add universal post-login background

### DIFF
--- a/code/add_class.php
+++ b/code/add_class.php
@@ -65,7 +65,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     </style>
 <link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
-<body>
+<body class="landing-page sidebar-collapse">
     <div class="container">
         <div class="header-nav">
             <a href="instructorhome.php">Home</a>

--- a/code/assets/css/dark-mode.css
+++ b/code/assets/css/dark-mode.css
@@ -34,3 +34,12 @@ body.dark-mode .btn.btn-primary {
 body.dark-mode .btn {
   color: #fff;
 }
+
+/* Background image for all logged in pages */
+body.landing-page.sidebar-collapse,
+body.login-page.sidebar-collapse {
+  background-image: url('../img/bg2.jpg');
+  background-size: cover;
+  background-position: top center;
+  background-attachment: fixed;
+}

--- a/code/assets/css/material-kit.css
+++ b/code/assets/css/material-kit.css
@@ -17910,3 +17910,12 @@ footer .pull-center {
 /* Custom fix for responsive navbar */
 .navbar-nav{flex-wrap:wrap;}
 
+/* Background image for all logged in pages */
+body.landing-page.sidebar-collapse,
+body.login-page.sidebar-collapse{
+  background-image:url('../img/bg2.jpg');
+  background-size:cover;
+  background-position:top center;
+  background-attachment:fixed;
+}
+

--- a/code/calculate_marks.php
+++ b/code/calculate_marks.php
@@ -155,7 +155,7 @@ $conn->close(); // Close connection here before outputting HTML
     </style>
 <link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
-<body>
+<body class="landing-page sidebar-collapse">
     <div class="container">
         <h3>Mark Calculation Status</h3>
         <div class="message <?php echo (strpos($message, 'Error:') === 0 || strpos($message, 'No responses') === 0 || strpos($message, 'No submission') === 0) ? 'message-error' : 'message-success'; ?>">

--- a/code/edit_class.php
+++ b/code/edit_class.php
@@ -97,7 +97,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['update_class']) && $cl
     </style>
 <link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
-<body>
+<body class="landing-page sidebar-collapse">
     <div class="container">
          <div class="header-nav">
             <a href="instructorhome.php">Home</a>

--- a/code/my_results.php
+++ b/code/my_results.php
@@ -84,7 +84,7 @@ $results = $stmt->get_result();
     </style>
 <link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
-<body>
+<body class="landing-page sidebar-collapse">
     <div class="container mt-4">
         <div class="row">
             <div class="col-12">

--- a/code/quizpage.php
+++ b/code/quizpage.php
@@ -764,7 +764,7 @@ try {
     </script>
 <link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
-<body>
+<body class="landing-page sidebar-collapse">
     <div class="wrapper">
         <div class="content">
             <div class="container-fluid">


### PR DESCRIPTION
## Summary
- apply the bg2.jpg background globally for logged in pages
- ensure CSS works for landing and login pages with sidebar collapse
- mark add_class.php, calculate_marks.php, edit_class.php, my_results.php and quizpage.php as logged in pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6847cfef0574832e97e2dd0ccbbff27e