### PR TITLE
Fix PHP syntax error in quizconfig.php

### DIFF
--- a/code/quizconfig.php
+++ b/code/quizconfig.php
@@ -166,6 +166,7 @@ function getAvailableQuestionsCount($conn, $chapter_ids) {
     return $counts;
 }
 
+?>
 <link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 // Add this JavaScript function before </head>
 echo "<script>


### PR DESCRIPTION
## Summary
- fix `quizconfig.php` parse error by closing PHP tag before HTML

## Testing
- `php -l code/quizconfig.php`
- `for file in code/*.php; do php -l "$file"; done`

------
https://chatgpt.com/codex/tasks/task_e_6847d233ffa0832ea58a446ce2728c14