### PR TITLE
Adjust card widths for cleaner layout

### DIFF
--- a/code/edit_quiz.php
+++ b/code/edit_quiz.php
@@ -435,6 +435,11 @@ $conn->close();
         height: auto;
         padding-top: 90px; /* Add space for fixed navbar */
     }
+
+    .card-login {
+        max-width: 900px;
+        margin: 0 auto;
+    }
     
     /* For better spacing */
     .form-row-mobile {

--- a/code/questionfeed.php
+++ b/code/questionfeed.php
@@ -920,7 +920,7 @@ function getChapters($conn, $class_id, $subject_id) {
       }
       
       .card-login {
-        max-width: 1200px;
+        max-width: 900px;
         margin: 0 auto;
         margin-top: -40px;
         margin-bottom: 60px;

--- a/code/quizconfig.php
+++ b/code/quizconfig.php
@@ -876,7 +876,7 @@ function saveSelectedQuestions() {
     }
     .card-login {
       margin: 0 auto;
-      max-width: 100%;
+      max-width: 900px;
     }
     .card-body {
       padding: 20px !important;

--- a/code/studentregister.php
+++ b/code/studentregister.php
@@ -17,6 +17,12 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <!-- CSS Files -->
   <link href="./assets/css/material-kit.css?v=2.0.4" rel="stylesheet" />
+  <style>
+    .card-login {
+      max-width: 650px;
+      margin: 0 auto;
+    }
+  </style>
   <script>
   function validate() {
       var passwordA = document.forms["register"]["password"].value; // Renamed to avoid conflict with global password if any


### PR DESCRIPTION
## Summary
- tune card width for student registration page
- reduce questionfeed card width
- limit quiz configuration form width
- cap edit quiz card width

## Testing
- `npm test` *(fails: no test specified)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847deea7c60832e80e355990b9762f2