### PR TITLE
Enable dynamic topic filter dropdowns

### DIFF
--- a/code/get_subjects.php
+++ b/code/get_subjects.php
@@ -1,0 +1,28 @@
+<?php
+header('Content-Type: application/json');
+include "database.php";
+$class_id = isset($_GET['class_id']) ? intval($_GET['class_id']) : 0;
+if ($class_id <= 0) {
+    echo json_encode([]);
+    exit;
+}
+$sql = "SELECT DISTINCT s.subject_id, s.subject_name
+        FROM subjects s
+        JOIN chapters c ON s.subject_id = c.subject_id
+        WHERE c.class_id = ?
+        ORDER BY s.subject_name";
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("i", $class_id);
+$stmt->execute();
+$result = $stmt->get_result();
+$subjects = [];
+while ($row = $result->fetch_assoc()) {
+    $subjects[] = [
+        'subject_id' => $row['subject_id'],
+        'subject_name' => $row['subject_name']
+    ];
+}
+$stmt->close();
+$conn->close();
+echo json_encode($subjects);
+?>

--- a/code/manage_classes_subjects.php
+++ b/code/manage_classes_subjects.php
@@ -1427,5 +1427,46 @@ $stmt->close();
     <script src="./assets/js/plugins/moment.min.js"></script>
     <script src="./assets/js/material-kit.js?v=2.0.4" type="text/javascript"></script>
 <script src="./assets/js/dark-mode.js"></script>
+
+    <script>
+    // Dynamic filter dropdowns for Topics management
+    $(document).ready(function(){
+        const classSelect = $('select[name="topic_class"]');
+        const subjectSelect = $('select[name="topic_subject"]');
+        const chapterSelect = $('select[name="topic_chapter"]');
+
+        // When class changes, load relevant subjects and clear chapters
+        classSelect.on('change', function(){
+            const classId = $(this).val();
+            subjectSelect.html('<option value="">Select Subject</option>');
+            chapterSelect.html('<option value="">Select Chapter</option>');
+            if(classId){
+                fetch('get_subjects.php?class_id=' + classId)
+                    .then(res => res.json())
+                    .then(data => {
+                        data.forEach(function(sub){
+                            subjectSelect.append('<option value="'+sub.subject_id+'">'+sub.subject_name+'</option>');
+                        });
+                    });
+            }
+        });
+
+        // When subject changes, load chapters for selected class and subject
+        subjectSelect.on('change', function(){
+            const classId = classSelect.val();
+            const subjectId = $(this).val();
+            chapterSelect.html('<option value="">Select Chapter</option>');
+            if(classId && subjectId){
+                fetch('get_chapters.php?class_id=' + classId + '&subject_id=' + subjectId)
+                    .then(res => res.json())
+                    .then(data => {
+                        data.forEach(function(ch){
+                            chapterSelect.append('<option value="'+ch.chapter_id+'">'+ch.chapter_name+'</option>');
+                        });
+                    });
+            }
+        });
+    });
+    </script>
 </body>
 </html> 


### PR DESCRIPTION
## Summary
- add `get_subjects.php` endpoint
- auto-update subject and chapter dropdowns in Manage Topics

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486199bb6c832ea200355e196475e7