### PR TITLE
Remove dark mode toggle from student home

### DIFF
--- a/code/assets/js/dark-mode.js
+++ b/code/assets/js/dark-mode.js
@@ -8,7 +8,7 @@ function initDarkMode(){
   }
   const navList=document.querySelector('.navbar .navbar-nav');
   const navContainer=document.querySelector('.navbar .container');
-  if(!document.getElementById('darkModeToggle')){
+  if(!window.DISABLE_DARK_MODE_TOGGLE && !document.getElementById('darkModeToggle')){
     if(navList){
       const li=document.createElement('li');
       li.className='nav-item d-flex align-items-center';
@@ -33,16 +33,23 @@ function initDarkMode(){
     }
   }
   const toggle=document.getElementById('darkModeToggle');
-  if(!toggle) return;
   function apply(d){
-    if(d){document.body.classList.add('dark-mode');toggle.checked=true;}
-    else{document.body.classList.remove('dark-mode');toggle.checked=false;}
+    if(d){
+      document.body.classList.add('dark-mode');
+      if(toggle) toggle.checked=true;
+    }
+    else{
+      document.body.classList.remove('dark-mode');
+      if(toggle) toggle.checked=false;
+    }
   }
-  toggle.addEventListener('change',function(){
-    const en=toggle.checked;
-    localStorage.setItem('darkMode',en?'on':'off');
-    apply(en);
-  });
+  if(toggle){
+    toggle.addEventListener('change',function(){
+      const en=toggle.checked;
+      localStorage.setItem('darkMode',en?'on':'off');
+      apply(en);
+    });
+  }
   const saved=localStorage.getItem('darkMode');
   apply(saved==='on');
 }

--- a/code/studenthome.php
+++ b/code/studenthome.php
@@ -254,14 +254,6 @@
               <i class="material-icons">power_settings_new</i></i> Log Out
             </a>
           </li>          
-          <li class="nav-item d-flex align-items-center">
-            <div class="togglebutton mb-0">
-                <label class="m-0">
-                  <input type="checkbox" id="darkModeToggle">
-                  <span class="toggle"></span>
-                </label>
-              </div>
-          </li>
         </ul>
       </div>
     </div>
@@ -358,6 +350,11 @@
   <script src="./assets/js/plugins/nouislider.min.js" type="text/javascript"></script>
   <script src="./assets/js/plugins/jquery.sharrre.js" type="text/javascript"></script>
   <script src="./assets/js/material-kit.js?v=2.0.4" type="text/javascript"></script>
+
+  <script>
+    // Disable dark mode toggle insertion on this page
+    window.DISABLE_DARK_MODE_TOGGLE = true;
+  </script>
   
   <script>
     $(document).ready(function() {


### PR DESCRIPTION
## Summary
- remove dark mode toggle markup from `studenthome.php`
- skip automatic toggle insertion on this page
- apply dark mode if previously set even without toggle

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6848730cf1d8832ebc8a408de59f0e8c