### PR TITLE
Fix footer overlap on instructor login

### DIFF
--- a/code/instructorlogin.php
+++ b/code/instructorlogin.php
@@ -169,11 +169,11 @@
 
         .footer {
             padding: 30px 0;
-            margin-top: 50px;
+            margin: 50px auto 0;
             background: #f8f9fa;
             border-top: 1px solid #eee;
             position: relative;
-            width: 100%;
+            width: 95%;
         }
         
         .footer .copyright {


### PR DESCRIPTION
## Summary
- adjust footer size on `instructorlogin.php` so it doesn't overlap with the login card

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68492b9efd20832e8c893a74bbc22fbf