### PR TITLE
Fix instructor delete confirmation modal

### DIFF
--- a/code/manage_instructors.php
+++ b/code/manage_instructors.php
@@ -119,7 +119,7 @@ if ($instructors_result && $instructors_result->num_rows > 0) {
                 <span>%s ( %s )</span>
                 <span>
                     <button type='button' class='btn btn-info btn-sm' onclick=\"editInstructor('%s','%s')\"><i class='material-icons'>edit</i></button>
-                    <button type='button' class='btn btn-danger btn-sm' onclick=\"deleteInstructor('%s')\"><i class='material-icons'>delete</i></button>
+                    <button type='button' class='btn btn-danger btn-sm delete-instructor-btn' data-email='%s' data-toggle='modal' data-target='#deleteModal'><i class='material-icons'>delete</i></button>
                 </span>
             </li>",
             htmlspecialchars($instructor_row['name']),
@@ -467,10 +467,12 @@ $conn->close();
             document.getElementById('instructorForm').scrollIntoView({behavior:'smooth'});
         }
 
-        function deleteInstructor(email) {
+
+        // Set up delete confirmation modal
+        $(document).on('click', '.delete-instructor-btn', function() {
+            var email = $(this).data('email');
             document.getElementById('deleteEmail').value = email;
-            $('#deleteModal').modal('show');
-        }
+        });
 
         // Reset form when header clicked
         document.querySelector('.card-header').addEventListener('click', function(){


### PR DESCRIPTION
## Summary
- adjust delete button markup to use data attributes and bootstrap modal
- setup click handler to populate hidden email field for deletion

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849521cf990832ebb536c898e544e98