### PR TITLE
Fix quote escaping in manage_instructors

### DIFF
--- a/code/manage_instructors.php
+++ b/code/manage_instructors.php
@@ -119,7 +119,7 @@ if ($instructors_result && $instructors_result->num_rows > 0) {
                 <span>%s ( %s )</span>
                 <span>
                     <button type='button' class='btn btn-info btn-sm' onclick=\"editInstructor('%s','%s')\"><i class='material-icons'>edit</i></button>
-                    <button type='button' class='btn btn-danger btn-sm' onclick="deleteInstructor('%s')"><i class='material-icons'>delete</i></button>
+                    <button type='button' class='btn btn-danger btn-sm' onclick=\"deleteInstructor('%s')\"><i class='material-icons'>delete</i></button>
                 </span>
             </li>",
             htmlspecialchars($instructor_row['name']),


### PR DESCRIPTION
## Summary
- escape quotes in manage_instructors.php to prevent parse error

## Testing
- `php -l code/manage_instructors.php`


------
https://chatgpt.com/codex/tasks/task_e_68495f6d0e78832e9cf0677f76e18428