### PR TITLE
Fix quizconfig insert placeholder mismatch

### DIFF
--- a/code/quizconfig.php
+++ b/code/quizconfig.php
@@ -1687,7 +1687,7 @@ function saveSelectedQuestions() {
                     ?, ?, ?, ?,
                     ?, ?, ?, ?,
                     ?, ?, ?, ?,
-                    ?, ?, ?, ?
+                    ?, ?, ?
                 )";
 
                   if (!empty($quiznumber)) {


### PR DESCRIPTION
## Summary
- correct placeholder count in the quizconfig insertion query

## Testing
- `php -l code/quizconfig.php`

------
https://chatgpt.com/codex/tasks/task_e_684aab611e24832eba3fddd98e7ce58e