### PR TITLE
Fix Manage Quizzes header spacing

### DIFF
--- a/code/manage_quizzes.php
+++ b/code/manage_quizzes.php
@@ -312,7 +312,7 @@ $conn->close();
         }
         .page-header {
             margin-top: 60px;
-            padding-top: 90px; /* Ensure content sits below fixed navbar */
+            padding-top: 120px; /* Ensure content sits below fixed navbar */
             min-height: calc(100vh - 60px);
             position: relative;
         }
@@ -408,7 +408,7 @@ $conn->close();
 
     <div class="main-container">
         <div class="page-header header-filter" style="background-image: url('./assets/img/bg2.jpg'); background-size: cover; background-position: top center;">
-            <div class="container" style="padding-top: 20vh;">
+            <div class="container" style="padding-top: 20px;">
                 <div class="row">
                     <div class="col-md-12 ml-auto mr-auto">
                         <div class="card card-login">


### PR DESCRIPTION
## Summary
- keep Manage Quizzes heading below navbar by increasing page-header padding
- use a small container top padding instead of large viewport relative spacing

## Testing
- `php -l code/manage_quizzes.php` *(fails: `php` not found)*
- `composer --version` *(fails: `composer` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684befb64f64832ea2130a6efc89f326