### PR TITLE
Fix Manage Quizzes layout for many quizzes

### DIFF
--- a/code/manage_quizzes.php
+++ b/code/manage_quizzes.php
@@ -314,6 +314,8 @@ $conn->close();
             margin-top: 60px;
             padding-top: 120px; /* Ensure content sits below fixed navbar */
             min-height: calc(100vh - 60px);
+            height: auto; /* Allow page to grow with content */
+            display: block; /* Disable flex centering */
             position: relative;
         }
         .card {


### PR DESCRIPTION
## Summary
- avoid flex centering for the Manage Quizzes header so large tables aren't pushed up

## Testing
- `php -l code/manage_quizzes.php`


------
https://chatgpt.com/codex/tasks/task_e_684bf11d7d7c832e87ea16be04022db6