### PR TITLE
Fix navbar layout on questionfeed and quizconfig

### DIFF
--- a/code/questionfeed.php
+++ b/code/questionfeed.php
@@ -1423,8 +1423,9 @@ function getChapters($conn, $class_id, $subject_id) {
     </div>
   </nav>
 
-  <div class="page-header header-filter clear-filter" style="background-image: url('./assets/img/bg2.jpg'); background-size: cover; background-position: top center; position: relative;">
-    <div class="container">
+  <div class="wrapper">
+    <div class="main main-raised">
+      <div class="container">
       <div class="row" style="margin-bottom: 50px; position: relative; z-index: 2;">
         <div class="col-lg-10 col-md-10 ml-auto mr-auto">
           <div class="card card-login">
@@ -1938,7 +1939,8 @@ function getChapters($conn, $class_id, $subject_id) {
         </div>
       </div>
     </div>
-  </div> 
+  </div>
+</div>
   <footer class="footer footer-default">
     <div class="container">
       <div class="copyright text-center">

--- a/code/quizconfig.php
+++ b/code/quizconfig.php
@@ -1165,8 +1165,9 @@ function saveSelectedQuestions() {
     </div>
   </nav>
 
-  <div class="page-header">
-    <div class="container">
+  <div class="wrapper">
+    <div class="main main-raised">
+      <div class="container">
       <div class="row justify-content-center">
         <div class="col-lg-10 col-md-12">
           <div class="card card-login">
@@ -2006,7 +2007,8 @@ function saveSelectedQuestions() {
         </div>
       </div>
     </div>
-  </div>  
+  </div>
+</div>
 
   <!-- Core JS Files -->
   <script src="./assets/js/core/jquery.min.js" type="text/javascript"></script>


### PR DESCRIPTION
## Summary
- switch `questionfeed.php` to use the modern wrapper layout
- switch `quizconfig.php` to use the modern wrapper layout

## Testing
- `php -l code/questionfeed.php` *(fails: command not found)*
- `php -l code/quizconfig.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf6f5b1c0832eb47eb04ecc791579