### PR TITLE
Fix navbar styling overrides

### DIFF
--- a/code/questionfeed.php
+++ b/code/questionfeed.php
@@ -615,30 +615,26 @@ function getChapters($conn, $class_id, $subject_id) {
     nav.navbar {
       z-index: 1050 !important; /* Higher than anything else */
     }
-    
+
     .page-header {
       z-index: 1 !important; /* Lower than navbar but higher than default */
     }
-    
+
     .page-header .container {
       position: relative !important;
       z-index: 3 !important; /* Higher than overlay */
     }
-    
+
     .card-login {
       z-index: 4 !important; /* Highest in page-header */
     }
-    
+
     /* Important fix for desktop navbar and header */
     @media (min-width: 992px) {
       body {
         padding-top: 60px; /* Account for fixed navbar height */
       }
-      
-      .navbar {
-        background-color: rgba(255, 255, 255, 0.95) !important;
-      }
-      
+
       .page-header {
         min-height: 100vh;
         height: auto !important;

--- a/code/quizconfig.php
+++ b/code/quizconfig.php
@@ -782,14 +782,7 @@ function saveSelectedQuestions() {
       padding-top: 70px;
       background-color: #f5f5f5;
     }
-    .navbar {
-      height: 50px;
-      background-color: #fff !important;
-      box-shadow: 0 2px 5px rgba(0,0,0,0.1);
-      padding: 0 !important;
-    }
     .navbar-translate {
-      height: 50px;
       display: flex;
       align-items: center;
     }


### PR DESCRIPTION
## Summary
- remove leftover navbar overrides so questionfeed.php and quizconfig.php use `navbar.css`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c1101b080832eb208c51162aa3890