### PR TITLE
Adjust spacing for question feed and quiz page

### DIFF
--- a/code/questionfeed.php
+++ b/code/questionfeed.php
@@ -852,7 +852,7 @@ function getChapters($conn, $class_id, $subject_id) {
     /* Desktop Specific Enhancements */
     @media (min-width: 992px) {
       .page-header {
-        padding-top: 120px !important;
+        padding-top: 150px !important; /* Increased spacing below navbar */
         padding-bottom: 60px !important;
         min-height: 100vh !important; /* Ensure full height */
       }
@@ -1159,7 +1159,7 @@ function getChapters($conn, $class_id, $subject_id) {
       .page-header { /* Main content container below navbar */
         height: auto !important; /* Allow it to grow with content */
         min-height: 0 !important; /* Override any vh-based min-height */
-        padding-top: 80px !important; /* Account for fixed navbar (60px) + some space */
+        padding-top: 100px !important; /* Extra space to prevent overlap */
         padding-bottom: 20px !important; /* Space before footer */
         overflow: visible !important; /* Ensure its content can overflow and make page scroll */
         display: block !important; /* Override flex if it's causing issues */

--- a/code/quizpage.php
+++ b/code/quizpage.php
@@ -672,6 +672,11 @@ try {
             border-radius: 8px;
             margin-top: 20px;
         }
+
+        /* Ensure main content starts below the navbar */
+        .content {
+            margin-top: 80px;
+        }
         .card-header-primary {
             background: linear-gradient(60deg, #ab47bc, #8e24aa);
             box-shadow: 0 4px 20px 0px rgba(0, 0, 0, 0.14), 0 7px 10px -5px rgba(156, 39, 176, 0.4);


### PR DESCRIPTION
## Summary
- add more spacing below the navbar on question feed page
- push quiz page content down to avoid overlap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c153f74f8832ea85b676e186957ff