### PR TITLE
Implement admin permission workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+request_audit.log

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ are provided under `sql/`.
 |---|---|
 |studentinfo| Store information about the registered students|
 |instrutorinfo| Store information about the Teacher and TAs|
+|admininfo| Administrative user accounts with OTP secrets|
+|instructor_requests| Tracks instructor modification requests|
 |quizrecord| Store information about latest quiz given by students|
 |response| Stores answers of the questions submitted by students|
 |result| Stores information about marks of students|
@@ -115,7 +117,7 @@ git clone https://github.com/ft-abhishekgupta/php-mysql-onlinequizportal
 
 * Open PHPMyAdmin
     1. Create Database **quiz**
-    1. Import ```quiz.sql``` in the database
+    1. Import ```sql/database_quiz.sql``` in the database
 
 * Modify ```database.php``` file with MySQL Credentials
 * Open Browser :

--- a/code/adminhome.php
+++ b/code/adminhome.php
@@ -1,0 +1,65 @@
+<?php
+session_start();
+if(!isset($_SESSION['adminloggedin']) || $_SESSION['adminloggedin'] !== true) {
+    header('Location: adminlogin.php');
+    exit;
+}
+include 'database.php';
+
+// Handle approve/deny
+if($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['request_id'], $_POST['action'])) {
+    $id = (int)$_POST['request_id'];
+    $action = ($_POST['action'] === 'approve') ? 'approved' : 'denied';
+    $comment = $conn->real_escape_string(trim($_POST['comment'] ?? ''));
+    $update = sprintf("UPDATE instructor_requests SET status='%s', admin_comment='%s', decision_at=NOW() WHERE id=%d", $action, $comment, $id);
+    $conn->query($update);
+    $log = sprintf("%s - Admin %d %s request %d\n", date('c'), $_SESSION['admin_id'], $action, $id);
+    file_put_contents('../request_audit.log', $log, FILE_APPEND);
+}
+
+$pending = $conn->query("SELECT * FROM instructor_requests WHERE status='pending' ORDER BY created_at ASC");
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin Dashboard</title>
+    <link rel="stylesheet" href="assets/css/modern.css">
+</head>
+<body>
+<div class="container" style="margin-top:60px;">
+    <h3>Pending Instructor Requests</h3>
+    <?php if($pending && $pending->num_rows > 0): ?>
+    <table class="table">
+        <thead><tr><th>ID</th><th>Instructor</th><th>Action</th><th>Details</th><th>Submitted</th><th>Decision</th></tr></thead>
+        <tbody>
+        <?php while($row = $pending->fetch_assoc()): ?>
+        <tr>
+            <td><?= $row['id'] ?></td>
+            <td><?= htmlspecialchars($row['instructor_email']) ?></td>
+            <td><?= htmlspecialchars($row['action']) ?></td>
+            <td><?= nl2br(htmlspecialchars($row['details'])) ?></td>
+            <td><?= $row['created_at'] ?></td>
+            <td>
+                <form method="post" style="display:inline-block;">
+                    <input type="hidden" name="request_id" value="<?= $row['id'] ?>">
+                    <input type="hidden" name="action" value="approve">
+                    <input type="text" name="comment" placeholder="Comment" class="form-control mb-2">
+                    <button class="btn btn-success btn-sm" type="submit">Approve</button>
+                </form>
+                <form method="post" style="display:inline-block;">
+                    <input type="hidden" name="request_id" value="<?= $row['id'] ?>">
+                    <input type="hidden" name="action" value="deny">
+                    <button class="btn btn-danger btn-sm" type="submit">Deny</button>
+                </form>
+            </td>
+        </tr>
+        <?php endwhile; ?>
+        </tbody>
+    </table>
+    <?php else: ?>
+    <p>No pending requests.</p>
+    <?php endif; ?>
+</div>
+</body>
+</html>

--- a/code/adminlogin.php
+++ b/code/adminlogin.php
@@ -1,0 +1,107 @@
+<?php
+session_start();
+include 'database.php';
+
+function base32_decode_custom($b32) {
+    $alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+    $b32 = strtoupper($b32);
+    $out = '';
+    $buffer = 0;
+    $bits = 0;
+    for ($i = 0; $i < strlen($b32); $i++) {
+        $v = strpos($alphabet, $b32[$i]);
+        if ($v === false) continue;
+        $buffer = ($buffer << 5) | $v;
+        $bits += 5;
+        if ($bits >= 8) {
+            $bits -= 8;
+            $out .= chr(($buffer & (0xFF << $bits)) >> $bits);
+        }
+    }
+    return $out;
+}
+
+function get_totp($secret, $timeSlice = null) {
+    if ($timeSlice === null) {
+        $timeSlice = floor(time() / 30);
+    }
+    $secretKey = base32_decode_custom($secret);
+    $time = chr(0).chr(0).chr(0).chr(0).pack('N*', $timeSlice);
+    $hmac = hash_hmac('sha1', $time, $secretKey, true);
+    $offset = ord($hmac[19]) & 0xf;
+    $code = (
+        ((ord($hmac[$offset]) & 0x7f) << 24) |
+        ((ord($hmac[$offset + 1]) & 0xff) << 16) |
+        ((ord($hmac[$offset + 2]) & 0xff) << 8) |
+        (ord($hmac[$offset + 3]) & 0xff)
+    ) % 1000000;
+    return str_pad($code, 6, '0', STR_PAD_LEFT);
+}
+
+$error = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['email'], $_POST['password']) && !isset($_POST['otp'])) {
+        $email = $conn->real_escape_string(trim($_POST['email']));
+        $password = $conn->real_escape_string(trim($_POST['password']));
+        $query = sprintf("SELECT id, otp_secret FROM admininfo WHERE email='%s' AND password='%s'", $email, $password);
+        $res = $conn->query($query);
+        if ($res && $res->num_rows === 1) {
+            $row = $res->fetch_assoc();
+            $_SESSION['pending_admin'] = $row['id'];
+            $_SESSION['otp_secret'] = $row['otp_secret'];
+        } else {
+            $error = 'Invalid credentials';
+        }
+    } elseif (isset($_POST['otp']) && isset($_SESSION['pending_admin'])) {
+        $otp = trim($_POST['otp']);
+        $code = get_totp($_SESSION['otp_secret']);
+        if (hash_equals($code, $otp)) {
+            $_SESSION['adminloggedin'] = true;
+            $_SESSION['admin_id'] = $_SESSION['pending_admin'];
+            unset($_SESSION['pending_admin'], $_SESSION['otp_secret']);
+            header('Location: adminhome.php');
+            exit;
+        } else {
+            $error = 'Invalid verification code';
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin Login</title>
+    <link rel="stylesheet" href="assets/css/modern.css">
+</head>
+<body>
+<div class="container" style="max-width:400px;margin-top:60px;">
+    <h3>Admin Login</h3>
+    <?php if(!isset($_SESSION['pending_admin'])): ?>
+    <form method="post">
+        <div class="form-group">
+            <label>Email</label>
+            <input type="email" name="email" class="form-control" required>
+        </div>
+        <div class="form-group">
+            <label>Password</label>
+            <input type="password" name="password" class="form-control" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Login</button>
+        <?php if($error) echo '<p class="text-danger">'.htmlspecialchars($error).'</p>'; ?>
+    </form>
+    <?php else: ?>
+    <p>A verification code has been generated. Enter it below.</p>
+    <form method="post">
+        <div class="form-group">
+            <label>Verification Code</label>
+            <input type="text" name="otp" class="form-control" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Verify</button>
+        <?php if($error) echo '<p class="text-danger">'.htmlspecialchars($error).'</p>'; ?>
+    </form>
+    <?php endif; ?>
+</div>
+</body>
+</html>

--- a/code/index.php
+++ b/code/index.php
@@ -248,6 +248,9 @@ if (isset($_SESSION['error'])) {
                             <a href="studentlogin.php" class="btn btn-primary btn-lg">
                                 <i class="material-icons">school</i> Student Login
                             </a>
+                            <a href="adminlogin.php" class="btn btn-primary btn-lg">
+                                <i class="material-icons">admin_panel_settings</i> Admin Login
+                            </a>
                         </div>
                     </div>
                 </div>

--- a/code/instructorhome.php
+++ b/code/instructorhome.php
@@ -245,6 +245,11 @@
             </a>
           </li>
           <li class="nav-item">
+            <a href="request_modification.php" class="nav-link">
+              <i class="material-icons">edit</i> Request Modification
+            </a>
+          </li>
+          <li class="nav-item">
             <a href="my_profile.php" class="nav-link">
               <i class="material-icons">person</i> My Profile
             </a>

--- a/code/request_modification.php
+++ b/code/request_modification.php
@@ -1,0 +1,57 @@
+<?php
+session_start();
+if(!isset($_SESSION['instructorloggedin']) || $_SESSION['instructorloggedin'] !== true){
+    header('Location: instructorlogin.php');
+    exit;
+}
+include 'database.php';
+
+$message = '';
+if($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $conn->real_escape_string(trim($_POST['action']));
+    $details = $conn->real_escape_string(trim($_POST['details']));
+    if($action && $details) {
+        $email = $conn->real_escape_string($_SESSION['email']);
+        $sql = sprintf("INSERT INTO instructor_requests (instructor_email, action, details) VALUES ('%s','%s','%s')",
+            $email, $action, $details);
+        if($conn->query($sql)) {
+            $message = '<p class="text-success">Request submitted for admin review.</p>';
+            $log = sprintf("%s - %s submitted request %d\n", date('c'), $email, $conn->insert_id);
+            file_put_contents('../request_audit.log', $log, FILE_APPEND);
+        } else {
+            $message = '<p class="text-danger">Error submitting request.</p>';
+        }
+    } else {
+        $message = '<p class="text-danger">All fields required.</p>';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Request Modification</title>
+    <link rel="stylesheet" href="assets/css/modern.css">
+</head>
+<body>
+<div class="container" style="max-width:600px;margin-top:60px;">
+    <h3>Request Content Modification</h3>
+    <?= $message ?>
+    <form method="post">
+        <div class="form-group">
+            <label>Action</label>
+            <select name="action" class="form-control" required>
+                <option value="delete">Delete</option>
+                <option value="update">Update</option>
+                <option value="other">Other</option>
+            </select>
+        </div>
+        <div class="form-group">
+            <label>Details and Rationale</label>
+            <textarea name="details" class="form-control" rows="5" required></textarea>
+        </div>
+        <button class="btn btn-primary" type="submit">Submit Request</button>
+    </form>
+</div>
+</body>
+</html>

--- a/sql/database_quiz.sql
+++ b/sql/database_quiz.sql
@@ -886,6 +886,50 @@ INSERT INTO `topics` (`topic_id`, `chapter_id`, `topic_name`, `created_at`, `upd
 (6, 6, 'Domain Eukarya', '2025-06-13 07:41:06', '2025-06-13 07:41:06'),
 (7, 6, 'Taxonomic Hierarchy', '2025-06-17 13:42:22', '2025-06-17 13:42:22');
 
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `admininfo`
+--
+
+CREATE TABLE `admininfo` (
+  `id` int(11) NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `email` varchar(255) NOT NULL,
+  `password` varchar(255) NOT NULL,
+  `otp_secret` varchar(32) NOT NULL,
+  `created_at` timestamp NULL DEFAULT current_timestamp()
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+
+--
+-- Dumping data for table `admininfo`
+--
+
+INSERT INTO `admininfo` (`id`, `name`, `email`, `password`, `otp_secret`, `created_at`) VALUES
+(1, 'Administrator', 'admin@example.com', 'adminpass', 'JBSWY3DPEHPK3PXP', '2025-06-19 07:20:00');
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `instructor_requests`
+--
+
+CREATE TABLE `instructor_requests` (
+  `id` int(11) NOT NULL,
+  `instructor_email` varchar(255) NOT NULL,
+  `action` varchar(255) NOT NULL,
+  `details` text NOT NULL,
+  `status` enum('pending','approved','denied') DEFAULT 'pending',
+  `admin_comment` text DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT current_timestamp(),
+  `decision_at` timestamp NULL DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+
+--
+-- Dumping data for table `instructor_requests`
+--
+
+
 --
 -- Indexes for dumped tables
 --
@@ -1044,6 +1088,20 @@ ALTER TABLE `topics`
   ADD KEY `idx_topic_chapter` (`chapter_id`);
 
 --
+-- Indexes for table `admininfo`
+--
+ALTER TABLE `admininfo`
+  ADD PRIMARY KEY (`id`),
+  ADD UNIQUE KEY `email` (`email`);
+
+--
+-- Indexes for table `instructor_requests`
+--
+ALTER TABLE `instructor_requests`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `fk_request_instructor` (`instructor_email`);
+
+--
 -- AUTO_INCREMENT for dumped tables
 --
 
@@ -1124,6 +1182,18 @@ ALTER TABLE `subjects`
 --
 ALTER TABLE `topics`
   MODIFY `topic_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=8;
+
+--
+-- AUTO_INCREMENT for table `admininfo`
+--
+ALTER TABLE `admininfo`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=2;
+
+--
+-- AUTO_INCREMENT for table `instructor_requests`
+--
+ALTER TABLE `instructor_requests`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=1;
 
 --
 -- Constraints for dumped tables
@@ -1249,6 +1319,12 @@ ALTER TABLE `studentinfo`
 --
 ALTER TABLE `topics`
   ADD CONSTRAINT `fk_topics_chapter` FOREIGN KEY (`chapter_id`) REFERENCES `chapters` (`chapter_id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+--
+-- Constraints for table `instructor_requests`
+--
+ALTER TABLE `instructor_requests`
+  ADD CONSTRAINT `fk_request_instructor` FOREIGN KEY (`instructor_email`) REFERENCES `instructorinfo` (`email`) ON DELETE CASCADE ON UPDATE CASCADE;
 COMMIT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;


### PR DESCRIPTION
## Summary
- add tables for admin accounts and instructor requests
- add admin login with two-factor authentication
- create admin dashboard for approving instructor requests
- allow instructors to submit modification requests
- surface admin login from home page
- merge admin schema into main `database_quiz.sql`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6853b8789170832e8591f2a59edc39f1