### PR TITLE
Fix question selector JSON parsing

### DIFF
--- a/code/database.php
+++ b/code/database.php
@@ -23,5 +23,4 @@
 
 	// Set session variables for timezone
 	$_SESSION['timezone'] = 'Asia/Karachi';
-	$_SESSION['timezone_offset'] = '+05:00';
-?>
+        $_SESSION['timezone_offset'] = '+05:00';

--- a/code/get_chapter_questions.php
+++ b/code/get_chapter_questions.php
@@ -1,6 +1,12 @@
 <?php
 include 'database.php';
 
+// If the database connection failed, return a JSON error immediately.
+if (isset($conn) && $conn->connect_errno) {
+    echo json_encode(['error' => 'Database connection failed: ' . $conn->connect_error]);
+    exit;
+}
+
 header('Content-Type: application/json');
 
 // Get parameters

--- a/code/quizconfig.php
+++ b/code/quizconfig.php
@@ -199,8 +199,15 @@ function updateAvailableQuestions() {
             url += '&topic_ids=' + topicIds.join(',');
         }
         fetch(url)
-            .then(response => response.json())
-            .then(data => {
+            .then(response => response.text())
+            .then(text => {
+                let data;
+                try {
+                    data = text.trim() === '' ? {} : JSON.parse(text);
+                } catch (e) {
+                    console.error('Failed to parse response:', text);
+                    throw new Error('Invalid JSON response');
+                }
                 // Update max values for each question type
                 $('#typea').attr('max', data.mcq);
                 $('#typeb').attr('max', data.numerical);
@@ -372,8 +379,15 @@ function loadQuestionsByType(type, containerId, chapterIds, topicIds) {
     }
 
     fetch(url)
-        .then(response => response.json())
-        .then(data => {
+        .then(response => response.text())
+        .then(text => {
+            let data;
+            try {
+                data = text.trim() === '' ? [] : JSON.parse(text);
+            } catch (e) {
+                console.error('Failed to parse response:', text);
+                throw new Error('Invalid JSON response');
+            }
             var container = $('#' + containerId + ' .questions-list');
             container.empty();
             


### PR DESCRIPTION
## Summary
- robustly check database connection when fetching chapter questions
- remove trailing PHP close tag from `database.php`
- parse AJAX responses manually to improve error reporting

## Testing
- `php -l code/get_chapter_questions.php`
- `php -l code/quizconfig.php`
- `php -l code/database.php`

------
https://chatgpt.com/codex/tasks/task_e_685af0debb14832eaa92c3b80403ef5a