### PR TITLE
Fix question selector tab visibility

### DIFF
--- a/code/quizconfig.php
+++ b/code/quizconfig.php
@@ -921,6 +921,14 @@ function saveSelectedQuestions() {
       color: #007bff;
       border-color: #007bff;
     }
+    /* Override Material Kit styles to ensure tab text is visible */
+    .question-tabs .nav-tabs .nav-item .nav-link {
+      color: #495057 !important;
+    }
+    .question-tabs .nav-tabs .nav-item .nav-link.active {
+      color: #007bff !important;
+      border-color: #007bff !important;
+    }
     .questions-list {
       max-height: 400px;
       overflow-y: auto;


### PR DESCRIPTION
## Summary
- override Material Kit nav style so the question selector tabs are visible

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685b92e5cebc832ebd17e34718961573