### PR TITLE
Fix modal overlay freeze

### DIFF
--- a/code/quizconfig.php
+++ b/code/quizconfig.php
@@ -355,8 +355,8 @@ function openQuestionSelector() {
     loadQuestionsByType('short', 'shortQuestions', chapterIds, topicIds);
     loadQuestionsByType('essay', 'essayQuestions', chapterIds, topicIds);
     
-    // Show the modal
-    $('#questionSelectorModal').modal('show');
+    // Ensure modal is attached to body before showing
+    $('#questionSelectorModal').appendTo('body').modal('show');
 }
 
 // Function to load questions by type


### PR DESCRIPTION
## Summary
- ensure question selection modal attaches to body before showing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685b94dfb50c832ebdbe2cb4ca9c39a7