### PR TITLE
Add helper to fix MCQ topic IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,17 @@ Multi Server Question Feed also works in this configuration, where instructor ca
 ![](./images/Screenshot12.png)
 ![](./images/Screenshot13.png)
 ![](./images/Screenshot14.png)
+## Fixing mismatched topic IDs
+If MCQ questions for a topic are missing from the selection modal, the topic identifiers in `mcqdb` might not match the IDs in the `topics` table.
+Run the helper script to realign them:
+
+```bash
+php "code/Extra files/fix_topic_ids.php"
+```
+This updates MCQ records containing "Archaea" to use the current ID for "Domain Archaea".
+
 ## Development Notes
+
 All PHP files were linted using `php -l` and no syntax errors were detected.
 
 ---

--- a/code/Extra files/fix_topic_ids.php
+++ b/code/Extra files/fix_topic_ids.php
@@ -1,0 +1,31 @@
+<?php
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+include 'database.php';
+
+$topicName = 'Domain Archaea';
+
+// find the current topic_id for Domain Archaea
+$sql = "SELECT topic_id FROM topics WHERE topic_name = '$topicName' LIMIT 1";
+$result = $conn->query($sql);
+
+if (!$result || $result->num_rows === 0) {
+    echo "Topic '$topicName' not found in topics table.";
+    exit;
+}
+
+$row = $result->fetch_assoc();
+$topicId = (int)$row['topic_id'];
+
+// update mcqdb rows that mention Archaea but have a different topic_id
+$update = "UPDATE mcqdb SET topic_id = $topicId WHERE chapter_id = 6 AND question LIKE '%Archaea%' AND topic_id <> $topicId";
+
+if ($conn->query($update)) {
+    echo "Updated " . $conn->affected_rows . " MCQ questions to topic_id $topicId.";
+} else {
+    echo "Failed to update MCQ questions: " . $conn->error;
+}
+
+$conn->close();
+?>


### PR DESCRIPTION
## Summary
- add `fix_topic_ids.php` script for aligning mcqdb entries
- document how to run the script in README

## Testing
- `php -l "code/Extra files/fix_topic_ids.php"`
- `find code -name '*.php' -print0 | xargs -0 -n 1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_685b9cf0ad70832ea3eb513c3b58b97f