### PR TITLE
Fix aria-hidden warning when closing question selector modal

### DIFF
--- a/code/quizconfig.php
+++ b/code/quizconfig.php
@@ -321,9 +321,12 @@ function validateQuestionCounts() {
 // Function to open question selector modal
 // Flag to track if manual question selection modal is active
 var manualSelectionActive = false;
+// Store element that triggered the question selector
+var questionSelectorTriggerElement = null;
 
 function openQuestionSelector() {
     manualSelectionActive = true;
+    questionSelectorTriggerElement = document.activeElement;
     var chapterIds = $('#chapter_ids').val();
     var topicIds = $('#topic_ids').val() || [];
     if(topicIds && topicIds.length > 0) {
@@ -2054,10 +2057,17 @@ function saveSelectedQuestions() {
           updateAvailableQuestions();
         });
 
-      // Reset manual selection flag when modal closes
-      $('#questionSelectorModal').on('hidden.bs.modal', function() {
-        manualSelectionActive = false;
-      });
+      // Handle modal focus and state when it closes
+      $('#questionSelectorModal')
+        .on('hide.bs.modal', function() {
+          if (questionSelectorTriggerElement) {
+            $(questionSelectorTriggerElement).focus();
+            questionSelectorTriggerElement = null;
+          }
+        })
+        .on('hidden.bs.modal', function() {
+          manualSelectionActive = false;
+        });
     });
   </script>
 <script src="./assets/js/dark-mode.js"></script>


### PR DESCRIPTION
## Summary
- track the element that opened the question selector modal
- restore focus to that element when the modal hides
- keep manual selection flag reset after closing

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: Missing script: "lint")*
- `php -l code/quizconfig.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba93fab48832ead89b942d62ac7af