### PR TITLE
Fix MCQ topic mapping helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,12 +173,13 @@ Multi Server Question Feed also works in this configuration, where instructor ca
 ![](./images/Screenshot14.png)
 ## Fixing mismatched topic IDs
 If MCQ questions for a topic are missing from the selection modal, the topic identifiers in `mcqdb` might not match the IDs in the `topics` table.
-Run the helper script to realign them:
+Run the helper script to realign them. The script now accepts an optional topic name
+and search term so it can be used for any topic:
 
 ```bash
-php "code/Extra files/fix_topic_ids.php"
+php "code/Extra files/fix_topic_ids.php" "Domain Archaea" "Archaea"
 ```
-This updates MCQ records containing "Archaea" to use the current ID for "Domain Archaea".
+This example updates MCQ records containing "Archaea" to use the current ID for "Domain Archaea".
 
 ## Development Notes
 

--- a/code/Extra files/fix_topic_ids.php
+++ b/code/Extra files/fix_topic_ids.php
@@ -1,7 +1,11 @@
 <?php
 require_once __DIR__ . '/../database.php';
 
-$topicName = 'Domain Archaea';
+// Allow passing a topic name and search term via CLI arguments
+// Usage: php fix_topic_ids.php [topic name] [search term]
+// Defaults handle the common "Domain Archaea" mismatch
+$topicName  = $argv[1] ?? 'Domain Archaea';
+$searchTerm = $argv[2] ?? 'Archaea';
 $topicId = null;
 
 $sql = "SELECT topic_id FROM topics WHERE topic_name = ? LIMIT 1";
@@ -21,7 +25,7 @@ if ($topicId === null) {
     exit(1);
 }
 
-$query = "UPDATE mcqdb SET topic_id=? WHERE question LIKE '%Archaea%'";
+$query = "UPDATE mcqdb SET topic_id=? WHERE question LIKE '%" . $conn->real_escape_string($searchTerm) . "%'";
 $stmt = $conn->prepare($query);
 if (!$stmt) {
     echo "Failed to prepare update: " . $conn->error . PHP_EOL;


### PR DESCRIPTION
## Summary
- make the `fix_topic_ids.php` helper accept a topic name and search term so it can be reused
- document the new usage in the README

## Testing
- `php -l "code/Extra files/fix_topic_ids.php"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0017be8c832e940804c0863f3546