### PR TITLE
Fix session initialization in database connector

### DIFF
--- a/code/database.php
+++ b/code/database.php
@@ -1,6 +1,11 @@
 <?php
-	// Set PHP default timezone to match your country's timezone
-	date_default_timezone_set('Asia/Karachi'); // Replace with your timezone
+        // Ensure a session is active before using \$_SESSION
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+
+        // Set PHP default timezone to match your country's timezone
+        date_default_timezone_set('Asia/Karachi'); // Replace with your timezone
 
 	$db_host = 'localhost';
 	$db_name = 'database';


### PR DESCRIPTION
## Summary
- ensure session_start is called in `database.php` before writing to `$_SESSION`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862cb8efbb4832b8fa1a13cbd3ec80e