### PR TITLE
Replace exam heading text in export

### DIFF
--- a/code/direct_export.php
+++ b/code/direct_export.php
@@ -390,7 +390,7 @@ $html = '<!DOCTYPE html>
         <html>
         <head>
             <meta charset="UTF-8">
-            <title>Created by Sir Hassan Tariq - ' . $title . '</title>
+            <title>Narowal Public School and College - ' . $title . '</title>
             <style>
                 body { 
                     font-family: Arial, sans-serif; 
@@ -546,7 +546,7 @@ $html .= '<div class="no-print" style="text-align: right; margin-bottom: 10px;">
 
 // Exam header section
 $html .= '<div class="exam-header">
-            <div class="exam-logo">Created by Sir Hassan Tariq</div>
+            <div class="exam-logo">Narowal Public School and College</div>
             <div class="exam-title">' . htmlspecialchars($quiz['quizname']) . '</div>
             <div class="exam-subtitle">Class: ' . htmlspecialchars($quiz['class_name'] ?? 'N/A') . ' | Subject: ' . htmlspecialchars($quiz['subject_name'] ?? 'N/A') . '</div>
           </div>';


### PR DESCRIPTION
## Summary
- Rebrand quiz export header to "Narowal Public School and College"
- Update HTML title accordingly for exported quizzes

## Testing
- `php -l code/direct_export.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6ab23e6f8832ca4f7f761afbe205f