### PR TITLE
Add Manage Notifications link to instructor navigation

### DIFF
--- a/code/edit_quiz.php
+++ b/code/edit_quiz.php
@@ -618,6 +618,11 @@ $conn->close();
             </a>
           </li>
           <li class="nav-item">
+            <a href="manage_notifications.php" class="nav-link">
+              <i class="material-icons">notifications</i> Manage Notifications
+            </a>
+          </li>
+          <li class="nav-item">
             <a href="my_profile.php" class="nav-link">
               <i class="material-icons">person</i> My Profile
             </a>

--- a/code/manage_classes_subjects.php
+++ b/code/manage_classes_subjects.php
@@ -851,6 +851,11 @@ $stmt->close();
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a href="manage_notifications.php" class="nav-link">
+                            <i class="material-icons">notifications</i> Manage Notifications
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a href="my_profile.php" class="nav-link">
                             <i class="material-icons">person</i> My Profile
                         </a>

--- a/code/manage_instructors.php
+++ b/code/manage_instructors.php
@@ -278,6 +278,11 @@ $conn->close();
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a href="manage_notifications.php" class="nav-link">
+                            <i class="material-icons">notifications</i> Manage Notifications
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a href="my_profile.php" class="nav-link">
                             <i class="material-icons">person</i> My Profile
                         </a>

--- a/code/manage_quizzes.php
+++ b/code/manage_quizzes.php
@@ -387,6 +387,11 @@ $conn->close();
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a href="manage_notifications.php" class="nav-link">
+                            <i class="material-icons">notifications</i> Manage Notifications
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a href="my_profile.php" class="nav-link">
                             <i class="material-icons">person</i> My Profile
                         </a>

--- a/code/manage_students.php
+++ b/code/manage_students.php
@@ -594,16 +594,21 @@ $conn->close();
                             <i class="material-icons">people</i> Manage Instructors
                         </a>
                     </li>
-                    <li class="nav-item">
-                        <a href="manage_students.php" class="nav-link">
-                            <i class="material-icons">group</i> Manage Students
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="my_profile.php" class="nav-link">
-                            <i class="material-icons">person</i> My Profile
-                        </a>
-                    </li>
+                            <li class="nav-item">
+                                <a href="manage_students.php" class="nav-link">
+                                    <i class="material-icons">group</i> Manage Students
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a href="manage_notifications.php" class="nav-link">
+                                    <i class="material-icons">notifications</i> Manage Notifications
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a href="my_profile.php" class="nav-link">
+                                    <i class="material-icons">person</i> My Profile
+                                </a>
+                            </li>
                     <li class="nav-item">
                         <a class="nav-link" rel="tooltip" title="" data-placement="bottom" href="instructorlogout.php" data-original-title="Get back to Login Page">
                             <i class="material-icons">power_settings_new</i> Log Out

--- a/code/my_profile.php
+++ b/code/my_profile.php
@@ -226,6 +226,11 @@ $conn->close();
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a href="manage_notifications.php" class="nav-link">
+                            <i class="material-icons">notifications</i> Manage Notifications
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a href="my_profile.php" class="nav-link">
                             <i class="material-icons">person</i> My Profile
                         </a>

--- a/code/questionfeed (1).php
+++ b/code/questionfeed (1).php
@@ -1345,6 +1345,11 @@ function getChapters($conn, $class_id, $subject_id) {
             </a>
           </li>
           <li class="nav-item">
+            <a href="manage_notifications.php" class="nav-link">
+              <i class="material-icons">notifications</i> Manage Notifications
+            </a>
+          </li>
+          <li class="nav-item">
             <a href="my_profile.php" class="nav-link">
               <i class="material-icons">person</i> My Profile
             </a>

--- a/code/questionfeed.php
+++ b/code/questionfeed.php
@@ -1345,6 +1345,11 @@ function getChapters($conn, $class_id, $subject_id) {
             </a>
           </li>
           <li class="nav-item">
+            <a href="manage_notifications.php" class="nav-link">
+              <i class="material-icons">notifications</i> Manage Notifications
+            </a>
+          </li>
+          <li class="nav-item">
             <a href="my_profile.php" class="nav-link">
               <i class="material-icons">person</i> My Profile
             </a>

--- a/code/quizconfig.php
+++ b/code/quizconfig.php
@@ -1095,16 +1095,21 @@ function saveSelectedQuestions() {
               <i class="material-icons">people</i> Manage Instructors
             </a>
           </li>
-          <li class="nav-item">
-            <a href="manage_students.php" class="nav-link">
-              <i class="material-icons">group</i> Manage Students
-            </a>
-          </li>
-          <li class="nav-item">
-            <a href="my_profile.php" class="nav-link">
-              <i class="material-icons">person</i> My Profile
-            </a>
-          </li>
+                    <li class="nav-item">
+                        <a href="manage_students.php" class="nav-link">
+                            <i class="material-icons">group</i> Manage Students
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="manage_notifications.php" class="nav-link">
+                            <i class="material-icons">notifications</i> Manage Notifications
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="my_profile.php" class="nav-link">
+                            <i class="material-icons">person</i> My Profile
+                        </a>
+                    </li>
           <li class="nav-item">
             <a class="nav-link" rel="tooltip" title="" data-placement="bottom" href="instructorlogout.php" data-original-title="Get back to Login Page">
               <i class="material-icons">power_settings_new</i> Log Out

--- a/code/quizhome.php
+++ b/code/quizhome.php
@@ -176,6 +176,11 @@ try {
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a href="manage_notifications.php" class="nav-link">
+                            <i class="material-icons">notifications</i> Manage Notifications
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a href="instructorlogout.php" class="nav-link">
                             <i class="material-icons">power_settings_new</i> Logout
                         </a>

--- a/code/view_questions.php
+++ b/code/view_questions.php
@@ -541,6 +541,11 @@
             </a>
           </li>
           <li class="nav-item">
+            <a href="manage_notifications.php" class="nav-link">
+              <i class="material-icons">notifications</i> Manage Notifications
+            </a>
+          </li>
+          <li class="nav-item">
             <a href="my_profile.php" class="nav-link">
               <i class="material-icons">person</i> My Profile
             </a>

--- a/code/view_quiz_results.php
+++ b/code/view_quiz_results.php
@@ -384,6 +384,11 @@ $conn->close();
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a href="manage_notifications.php" class="nav-link">
+                            <i class="material-icons">notifications</i> Manage Notifications
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a href="my_profile.php" class="nav-link">
                             <i class="material-icons">person</i> My Profile
                         </a>

--- a/code/view_student_attempt.php
+++ b/code/view_student_attempt.php
@@ -438,6 +438,11 @@ $conn->close();
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a href="manage_notifications.php" class="nav-link">
+                            <i class="material-icons">notifications</i> Manage Notifications
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a href="my_profile.php" class="nav-link">
                             <i class="material-icons">person</i> My Profile
                         </a>


### PR DESCRIPTION
## Summary
- add "Manage Notifications" link to instructor navigation bar across all pages
- ensure the button is available alongside other management links

## Testing
- `php -l code/edit_quiz.php code/manage_classes_subjects.php code/manage_instructors.php code/manage_quizzes.php code/manage_students.php code/my_profile.php "code/questionfeed (1).php" code/questionfeed.php code/quizconfig.php code/quizhome.php code/view_questions.php code/view_quiz_results.php code/view_student_attempt.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6e0464968832c992471f4752513b0