### PR TITLE
Add serial numbers to quiz results table

### DIFF
--- a/code/view_quiz_results.php
+++ b/code/view_quiz_results.php
@@ -111,6 +111,7 @@ if ($selected_quiz_number > 0) {
                         <table class="table">
                             <thead class="text-primary">
                                 <tr>
+                                    <th>#</th>
                                     <th>Class</th>
                                     <th>Section</th>
                                     <th>Student Name</th>
@@ -129,6 +130,7 @@ if ($selected_quiz_number > 0) {
                             </thead>
                             <tbody>';
 
+                            $serial_number = 1;
                             while ($row = $results->fetch_assoc()) {
                 $percentage = ($row['total_marks'] / $quiz_info['maxmarks']) * 100;
                 $row_class = '';
@@ -141,6 +143,7 @@ if ($selected_quiz_number > 0) {
                 $student_pdf_link = 'direct_export.php?quiz_id=' . $selected_quiz_number . '&student=' . $row['rollnumber'] . '&attempt=' . $row['attempt'] . '&student_specific=1';
 
                 $quiz_results_html .= '<tr class="' . $row_class . '">
+                    <td>' . $serial_number++ . '</td>
                     <td>' . htmlspecialchars($row['class_name'] ?? 'N/A') . '</td>
                     <td>' . htmlspecialchars($row['section_name'] ?? 'N/A') . '</td>
                     <td>' . htmlspecialchars($row['student_name']) . '</td>


### PR DESCRIPTION
## Summary
- Add serial number column to quiz results table header for easier student counting.
- Track and display incrementing serial numbers for each student row.

## Testing
- `php -l code/view_quiz_results.php`


------
https://chatgpt.com/codex/tasks/task_e_68a74c1d9c04832c901de42dc484e74e