### PR TITLE
Handle database connection errors gracefully

### DIFF
--- a/code/database.php
+++ b/code/database.php
@@ -1,31 +1,43 @@
 <?php
-	 // Ensure a session is active before using \$_SESSION
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
+// Ensure a session is active before using \$_SESSION
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 
-        // Set PHP default timezone to match your country's timezone
-        date_default_timezone_set('Asia/Karachi'); // Replace with your timezone
+// Set PHP default timezone to match your country's timezone
+date_default_timezone_set('Asia/Karachi'); // Replace with your timezone
 
-	$db_host = 'localhost';
-	$db_name = 'database';
-	$db_user = 'username';
-	$db_pass = 'password';
-	$conn = new mysqli($db_host,$db_user,$db_pass,$db_name);
-	if($conn->connect_error){
-		printf("Connect failed: %s\n",$conn->connect_error);
-		// Log error as well before exiting
-		error_log("Database Connection Failed: " . $conn->connect_error, 3, "quiz_errors.log");
-		exit; // Consider a more user-friendly die message or error page
-	}
+$db_host = 'localhost';
+$db_name = 'database';
+$db_user = 'username';
+$db_pass = 'password';
 
-	// Set session timezone to match PHP timezone
-	if (!$conn->query("SET time_zone = '+05:00'")) { // Replace +05:00 with your timezone offset
-		// Failed to set timezone, log error. 
-		// Depending on importance, you might want to die() here or handle it.
-		error_log("Failed to set database session timezone: " . $conn->error, 3, "quiz_errors.log");
-	}
+$conn = null;
 
-	// Set session variables for timezone
-	$_SESSION['timezone'] = 'Asia/Karachi';
-        $_SESSION['timezone_offset'] = '+05:00';
+// Attempt to create the database connection. Newer versions of PHP throw
+// mysqli_sql_exception on connection failure. Catch the exception so that the
+// calling script can handle the error and return a clean JSON response.
+try {
+    $conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
+} catch (mysqli_sql_exception $e) {
+    error_log('Database Connection Failed: ' . $e->getMessage(), 3, 'quiz_errors.log');
+    $conn = null;
+}
+
+// If the connection object exists but has an error, log it without producing
+// any output that could corrupt API responses.
+if ($conn && $conn->connect_error) {
+    error_log('Database Connection Failed: ' . $conn->connect_error, 3, 'quiz_errors.log');
+}
+
+if ($conn) {
+    // Set session timezone to match PHP timezone
+    if (!$conn->query("SET time_zone = '+05:00'")) { // Replace +05:00 with your timezone offset
+        // Failed to set timezone, log error.
+        error_log('Failed to set database session timezone: ' . $conn->error, 3, 'quiz_errors.log');
+    }
+
+    // Set session variables for timezone
+    $_SESSION['timezone'] = 'Asia/Karachi';
+    $_SESSION['timezone_offset'] = '+05:00';
+}

--- a/code/get_chapter_questions.php
+++ b/code/get_chapter_questions.php
@@ -1,8 +1,15 @@
 <?php
 include 'database.php';
 
-// If the database connection failed, return a JSON error immediately.
-if (isset($conn) && $conn->connect_errno) {
+// If the database connection failed, return a JSON error immediately. The
+// database bootstrap file deliberately avoids emitting output on failure so
+// that we can send a clean JSON response here.
+if (!isset($conn) || $conn === null) {
+    echo json_encode(['error' => 'Database connection failed']);
+    exit;
+}
+
+if ($conn->connect_errno) {
     echo json_encode(['error' => 'Database connection failed: ' . $conn->connect_error]);
     exit;
 }


### PR DESCRIPTION
## Summary
- avoid emitting plain text when the database connection fails
- ensure get_chapter_questions.php responds with structured JSON on DB errors

## Testing
- `php -l code/database.php`
- `php -l code/get_chapter_questions.php`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e00fbffc832c90476e0caa6ce634