### PR TITLE
Prevent duplicate questions in quizzes

### DIFF
--- a/code/quizpage.php
+++ b/code/quizpage.php
@@ -274,7 +274,8 @@ if (isset($_SESSION['quiz_started']) && $_SESSION['quiz_started'] === true) {
                         throw new Exception("No valid chapters found");
                     }
                     
-                    $sql = "SELECT id FROM $table WHERE chapter_id IN ($chapter_ids_str)";
+                    // Use DISTINCT to avoid retrieving the same question multiple times
+                    $sql = "SELECT DISTINCT id FROM $table WHERE chapter_id IN ($chapter_ids_str)";
                     if (!empty($topic_ids_str)) {
                         $sql .= " AND topic_id IN ($topic_ids_str)";
                     }
@@ -401,6 +402,18 @@ if (isset($_SESSION['quiz_started']) && $_SESSION['quiz_started'] === true) {
                 throw new Exception("Failed to get required questions: " . $e->getMessage());
             }
             
+            // Remove any duplicate questions that might have been selected
+            $unique_questions = [];
+            $seen = [];
+            foreach ($questions as $q) {
+                $key = $q['type'] . '-' . $q['id'];
+                if (!isset($seen[$key])) {
+                    $seen[$key] = true;
+                    $unique_questions[] = $q;
+                }
+            }
+            $questions = $unique_questions;
+
             // Check if we got enough questions
             if (count($questions) > 0) {
                 logDebug("Got questions", array('count' => count($questions)));

--- a/code/randomqgen.php
+++ b/code/randomqgen.php
@@ -66,7 +66,8 @@ function selectrand($conn1, $count, $type, $rollno, $quizid, $attempt) {
             return;
     }
 
-    $sql = "SELECT id FROM $table ORDER BY RAND() LIMIT " . intval($count);
+    // Ensure we don't select the same question more than once
+    $sql = "SELECT DISTINCT id FROM $table ORDER BY RAND() LIMIT " . intval($count);
     $result = $conn1->query($sql);
 
     if ($result && $result->num_rows > 0) {


### PR DESCRIPTION
## Summary
- Avoid selecting identical questions by querying distinct IDs when building quizzes
- Deduplicate the final question list before storing it to ensure uniqueness

## Testing
- `php -l code/randomqgen.php`
- `php -l code/quizpage.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a812b1741c832c8e57cbfa1c73e834