### PR TITLE
Ensure topic and question APIs return clean JSON

### DIFF
--- a/code/get_chapter_questions.php
+++ b/code/get_chapter_questions.php
@@ -7,20 +7,30 @@
  * response.
  */
 
-// Start output buffering to capture any stray warnings/notices.
+// Start output buffering to capture any stray warnings/notices that might
+// corrupt JSON output.
 ob_start();
 
 include 'database.php';
 
 /**
  * Helper function to emit a clean JSON response and terminate the script.
+ * This function ensures that any buffered output is discarded before the
+ * JSON payload is sent to the client.
  */
 function send_json($data) {
-    if (ob_get_length()) {
-        ob_clean();
+    $json = json_encode($data);
+    if ($json === false) {
+        $json = json_encode(['error' => 'JSON encoding failed: ' . json_last_error_msg()]);
     }
+
+    // Remove any previously buffered output to guarantee valid JSON
+    while (ob_get_level()) {
+        ob_end_clean();
+    }
+
     header('Content-Type: application/json');
-    echo json_encode($data);
+    echo $json;
     exit;
 }
 


### PR DESCRIPTION
## Summary
- Guarantee clean JSON responses from chapter question loader by clearing output buffers and validating encoding
- Apply the same buffering and error handling to question count and topic endpoints

## Testing
- `php -l code/get_chapter_questions.php`
- `php -l code/get_question_counts.php`
- `php -l code/get_topics.php`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a8195dc268832caffddad2dcffa0a0