### PR TITLE
Handle invalid UTF-8 in question APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ request_audit.log
 /android/.gradle/
 /android/local.properties
 /android/app/build/
+/android/build/
+code/node_modules/

--- a/code/database.php
+++ b/code/database.php
@@ -31,6 +31,12 @@ if ($conn && $conn->connect_error) {
 }
 
 if ($conn) {
+    // Ensure the connection uses UTF-8 so JSON encoding doesn't fail on
+    // characters stored with a different encoding in the database.
+    if (!$conn->set_charset('utf8mb4')) {
+        error_log('Failed to set database connection charset: ' . $conn->error, 3, 'quiz_errors.log');
+    }
+
     // Set session timezone to match PHP timezone
     if (!$conn->query("SET time_zone = '+05:00'")) { // Replace +05:00 with your timezone offset
         // Failed to set timezone, log error.

--- a/code/get_chapter_questions.php
+++ b/code/get_chapter_questions.php
@@ -19,7 +19,10 @@ include 'database.php';
  * JSON payload is sent to the client.
  */
 function send_json($data) {
-    $json = json_encode($data);
+    // Replace invalid UTF-8 sequences rather than failing so that questions
+    // containing characters stored with a different encoding still return
+    // a valid JSON response.
+    $json = json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE);
     if ($json === false) {
         $json = json_encode(['error' => 'JSON encoding failed: ' . json_last_error_msg()]);
     }

--- a/code/get_question_counts.php
+++ b/code/get_question_counts.php
@@ -6,7 +6,9 @@ include 'database.php';
 
 // Helper to emit a JSON response and terminate.
 function send_json($data) {
-    $json = json_encode($data);
+    // Use JSON_INVALID_UTF8_SUBSTITUTE so invalid sequences do not cause
+    // json_encode to fail when question text contains mixed encodings.
+    $json = json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE);
     if ($json === false) {
         $json = json_encode(['error' => 'JSON encoding failed: ' . json_last_error_msg()]);
     }

--- a/code/get_topics.php
+++ b/code/get_topics.php
@@ -6,7 +6,10 @@ header('Content-Type: application/json');
 include "database.php";
 
 function send_json($data) {
-    $json = json_encode($data);
+    // Use JSON_INVALID_UTF8_SUBSTITUTE to replace any invalid UTF-8 sequences
+    // instead of failing outright, which previously caused errors when
+    // topics contained characters stored with a different encoding.
+    $json = json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE);
     if ($json === false) {
         $json = json_encode(['error' => 'JSON encoding failed: ' . json_last_error_msg()]);
     }


### PR DESCRIPTION
## Summary
- Ensure database connection uses UTF-8 to avoid JSON encoding failures
- Replace invalid UTF-8 sequences when encoding JSON for topics and questions
- Ignore build and node_modules directories

## Testing
- `php -l code/database.php`
- `php -l code/get_topics.php`
- `php -l code/get_chapter_questions.php`
- `php -l code/get_question_counts.php`


------
https://chatgpt.com/codex/tasks/task_e_68a81be0a46c832c9a4513a918511a58