### PR TITLE
Hide navigation overlay to fix edit quiz page

### DIFF
--- a/code/assets/css/navbar.css
+++ b/code/assets/css/navbar.css
@@ -56,3 +56,9 @@
     padding: 0.8vh 1vw !important;
   }
 }
+
+/* Hide navigation overlay from Material Kit that blocks page interaction */
+#bodyClick {
+  display: none !important;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- hide Material Kit's `#bodyClick` overlay via CSS so header no longer blocks interactions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f04fa954832c9fc25a4b0c976b3c