### PR TITLE
Prevent early quiz start

### DIFF
--- a/code/quizpage.php
+++ b/code/quizpage.php
@@ -464,9 +464,9 @@ if (isset($_SESSION['quiz_started']) && $_SESSION['quiz_started'] === true) {
                 throw new Exception("No questions available for this quiz");
             }
         } else {
-            logDebug("No active quiz found for rollnumber: $rollnumber. Redirecting to quizhome.");
+            logDebug("No active quiz found for rollnumber: $rollnumber. Redirecting to studenthome.");
             $_SESSION['error'] = "No available quiz found. Please check back later.";
-            header("location: quizhome.php");
+            header("location: studenthome.php");
             exit;
         }
     } catch (Exception $e) {
@@ -476,9 +476,9 @@ if (isset($_SESSION['quiz_started']) && $_SESSION['quiz_started'] === true) {
             'quiz_data' => isset($quiz) ? $quiz : null
         ));
         $_SESSION['error'] = "Error initializing quiz: " . $e->getMessage() . ". Please try again or contact administrator.";
-        logDebug("Redirecting to quizhome due to error during quiz initialization.", array('error_message' => $_SESSION['error']));
+        logDebug("Redirecting to studenthome due to error during quiz initialization.", array('error_message' => $_SESSION['error']));
         ob_end_clean();
-        header("location: quizhome.php");
+        header("location: studenthome.php");
         exit;
     }
 }

--- a/code/studenthome.php
+++ b/code/studenthome.php
@@ -334,7 +334,11 @@
                 <h4 class="card-title">Take Quiz</h4>
                 <p class="card-text">Start your quiz now</p>
                 <?php if(isset($upcoming_quiz) && $upcoming_quiz): ?>
-                  <a href="quizpage.php" class="btn btn-primary">Start Quiz</a>
+                  <?php if(strtotime($upcoming_quiz['starttime']) <= time()): ?>
+                    <a href="quizpage.php" class="btn btn-primary">Start Quiz</a>
+                  <?php else: ?>
+                    <a href="#" class="btn btn-primary" onclick="alert('Quiz has not started yet. Please wait for the start time.'); return false;">Start Quiz</a>
+                  <?php endif; ?>
                 <?php else: ?>
                   <a href="#" class="btn btn-primary" onclick="alert('No quiz is currently available.'); return false;">Start Quiz</a>
                 <?php endif; ?>


### PR DESCRIPTION
## Summary
- Check quiz start time on student home and block early navigation.
- Redirect to student home when no active quiz or initialization error occurs.

## Testing
- `php -l code/studenthome.php`
- `php -l code/quizpage.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac92d2ba40832cb8173698a3d4ad42