### PR TITLE
Refactor quiz admin pages to new UI layout

### DIFF
--- a/code/manage_quizzes.php
+++ b/code/manage_quizzes.php
@@ -414,20 +414,17 @@ $conn->close();
         </div>
     </nav>
 
-    <div class="main-container">
-        <div class="page-header header-filter" style="background-image: url('./assets/img/bg2.jpg'); background-size: cover; background-position: top center;">
-            <div class="container" style="padding-top: 20px;">
-                <div class="row">
-                    <div class="col-md-12 ml-auto mr-auto">
-                        <div class="card card-login">
-                            <div class="card-header card-header-primary text-center">
-                                <h4 class="card-title">Manage Quizzes</h4>
-                            </div>
-                            <div class="card-body">
-                                <?php echo $feedback_message; ?>
-                                
-                                <!-- Filter Form -->
-                                <form method="GET" action="manage_quizzes.php" class="mb-4">
+    <div class="wrapper">
+        <div class="main main-raised">
+            <div class="container">
+                <div class="section text-center">
+                    <h2 class="title">Manage Quizzes</h2>
+                </div>
+                <div class="section">
+                    <?php echo $feedback_message; ?>
+
+                    <!-- Filter Form -->
+                    <form method="GET" action="manage_quizzes.php" class="mb-4">
                                     <div class="row">
                                         <div class="col-md-4">
                                             <div class="form-group">
@@ -509,18 +506,13 @@ $conn->close();
                                         </table>
                                     </div>
                                 <?php endif; ?>
-                            </div>
-                            <div class="card-footer text-center">
-                                <a href="quizconfig.php" class="btn btn-primary">Add New Quiz</a>
-                            </div>
-                        </div>
+                    <div class="text-center mt-4">
+                        <a href="quizconfig.php" class="btn btn-primary">Add New Quiz</a>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
-
-    <footer class="footer footer-default">
+        <footer class="footer footer-default">
         <div class="container">
             <div class="copyright text-center">
                 <div class="department">A Project of StudyHT.com</div>
@@ -531,6 +523,8 @@ $conn->close();
             </div>
         </div>
     </footer>
+
+    </div> <!-- wrapper -->
 
     <!--   Core JS Files   -->
     <script src="./assets/js/core/jquery.min.js" type="text/javascript"></script>

--- a/code/quizconfig.php
+++ b/code/quizconfig.php
@@ -190,7 +190,6 @@ function getAvailableQuestionsCount($conn, $chapter_ids) {
 }
 
 ?>
-<link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 <script>
 function updateAvailableQuestions() {
     var chapterIds = $('#chapter_ids').val();
@@ -1149,19 +1148,20 @@ function saveSelectedQuestions() {
     </div>
   </nav>
 
-  <div class="main-container">
-    <div class="page-header header-filter" style="background-image: url('./assets/img/bg2.jpg'); background-size: cover; background-position: top center;">
-      <div class="container" style="padding-top: 20px;">
-      <div class="row justify-content-center">
-        <div class="col-lg-10 col-md-12">
-          <div class="card card-login">
-            <form class="form" name="quizconfig" action="quizconfig.php" method="post">
-              <div class="card-header card-header-primary text-center">
-                <h4 class="card-title">Set Quiz</h4>
-                <p class="description">Set the pattern of the next quiz</p>
-              </div>
-              
-              <div class="card-body">
+  <div class="wrapper">
+    <div class="main main-raised">
+      <div class="container">
+        <div class="section">
+          <div class="row justify-content-center">
+            <div class="col-lg-10 col-md-12">
+              <div class="card">
+                <form class="form" name="quizconfig" action="quizconfig.php" method="post">
+                  <div class="card-header card-header-primary text-center">
+                    <h4 class="card-title">Set Quiz</h4>
+                    <p class="description">Set the pattern of the next quiz</p>
+                  </div>
+
+                  <div class="card-body">
                 <!-- Quiz Basic Info -->
                 <div class="row form-row-mobile">
                   <div class="col-md-6 col-12 mb-3">
@@ -2037,12 +2037,24 @@ function saveSelectedQuestions() {
             ?>
               </div>
             <?php endif; ?>
-          </div>
-        </div>
+          </div> <!-- card -->
+        </div> <!-- col -->
+      </div> <!-- row -->
+    </div> <!-- section -->
+  </div> <!-- container -->
+</div> <!-- main -->
+<footer class="footer footer-default">
+  <div class="container">
+    <div class="copyright text-center">
+      <div class="department">A Project of StudyHT.com</div>
+      <div class="designer">Designed and Developed by Sir Hassan Tariq</div>
+      <div class="year">
+        &copy; <script>document.write(new Date().getFullYear())</script>
       </div>
     </div>
   </div>
-</div>
+</footer>
+</div> <!-- wrapper -->
 
   <!-- Core JS Files -->
   <script src="./assets/js/core/jquery.min.js" type="text/javascript"></script>

--- a/code/view_quiz_results.php
+++ b/code/view_quiz_results.php
@@ -422,7 +422,7 @@ $conn->close();
                 </div>
                 <div class="section">
                     <div class="card mb-4">
-                        <div class="card-header card-header-info">
+                        <div class="card-header card-header-primary">
                             <h4 class="card-title mb-0">Download Student Results</h4>
                         </div>
                         <div class="card-body">


### PR DESCRIPTION
## Summary
- Rework quiz configuration page with wrapper layout and shared footer
- Move manage quizzes view to modern UI structure with header title and footer
- Align quiz results card styling with primary theme

## Testing
- `php -l code/quizconfig.php`
- `php -l code/manage_quizzes.php`
- `php -l code/view_quiz_results.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5e403460c832c84a45f12caba6c05