### PR TITLE
Integrate sidebar layout across instructor pages

### DIFF
--- a/code/manage_instructors.php
+++ b/code/manage_instructors.php
@@ -86,6 +86,7 @@ $conn->close();
     <link href="./assets/css/modern.css" rel="stylesheet" />
     <link href="./assets/css/navbar.css" rel="stylesheet" />
     <link href="./assets/css/portal.css" rel="stylesheet" />
+    <link href="./assets/css/sidebar.css" rel="stylesheet" />
     <style>
         /* Fixed Navbar Styles */
         .navbar {
@@ -222,89 +223,12 @@ $conn->close();
     </style>
 <link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
-<body class="landing-page sidebar-collapse">
-    <nav class="navbar main-navbar fixed-top navbar-expand-lg">
-        <div class="container">
-            <div class="navbar-translate">
-                <a class="navbar-brand" href="instructorhome.php">Quiz Portal</a>
-                <button class="navbar-toggler" type="button" data-toggle="collapse" aria-expanded="false" aria-label="Toggle navigation">
-                    <span class="sr-only">Toggle navigation</span>
-                    <span class="navbar-toggler-icon"></span>
-                    <span class="navbar-toggler-icon"></span>
-                    <span class="navbar-toggler-icon"></span>
-                    <span class="navbar-toggler-icon"></span>
-                </button>
-            </div>
-            <div class="collapse navbar-collapse">
-                <ul class="navbar-nav mx-auto">
-                    <li class="nav-item">
-                        <a href="manage_classes_subjects.php" class="nav-link">
-                            <i class="material-icons">school</i> Manage Classes & Subjects
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="questionfeed.php" class="nav-link">
-                            <i class="material-icons">input</i> Feed Questions
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="view_questions.php" class="nav-link">
-                            <i class="material-icons">list_alt</i> Questions Bank
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="quizconfig.php" class="nav-link">
-                            <i class="material-icons">layers</i> Set Quiz
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="manage_quizzes.php" class="nav-link">
-                            <i class="material-icons">settings</i> Manage Quizzes
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="view_quiz_results.php" class="nav-link">
-                            <i class="material-icons">assessment</i> View Results
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="manage_instructors.php" class="nav-link">
-                            <i class="material-icons">people</i> Manage Instructors
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="manage_students.php" class="nav-link">
-                            <i class="material-icons">group</i> Manage Students
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="manage_notifications.php" class="nav-link">
-                            <i class="material-icons">notifications</i> Manage Notifications
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="my_profile.php" class="nav-link">
-                            <i class="material-icons">person</i> My Profile
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" rel="tooltip" title="" data-placement="bottom" href="instructorlogout.php" data-original-title="Get back to Login Page">
-                            <i class="material-icons">power_settings_new</i> Log Out
-                        </a>
-                    </li>
-          <li class="nav-item d-flex align-items-center">
-            <div class="togglebutton mb-0">
-                <label class="m-0">
-                  <input type="checkbox" id="darkModeToggle">
-                  <span class="toggle"></span>
-                </label>
-              </div>
-          </li>
-                </ul>
-            </div>
-        </div>
-    </nav>
-
+<body class="dark-mode">
+<div class="layout">
+  <?php include './includes/sidebar.php'; ?>
+  <div class="main">
+    <?php include './includes/header.php'; ?>
+    <main class="content">
     <div class="wrapper">
         <div class="main main-raised">
             <div class="container">
@@ -364,6 +288,9 @@ $conn->close();
             </div>
         </footer>
     </div>
+    </main>
+  </div>
+</div>
 
     <!--   Core JS Files   -->
     <script src="./assets/js/core/jquery.min.js" type="text/javascript"></script>
@@ -372,6 +299,7 @@ $conn->close();
     <script src="./assets/js/plugins/moment.min.js"></script>
     <script src="./assets/js/material-kit.js?v=2.0.4" type="text/javascript"></script>
 <script src="./assets/js/dark-mode.js"></script>
+<script src="./assets/js/sidebar.js"></script>
     <!-- No additional inline scripts needed -->
 </body>
 </html>

--- a/code/manage_notifications.php
+++ b/code/manage_notifications.php
@@ -98,9 +98,10 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <!-- CSS Files -->
   <link href="./assets/css/material-kit.css?v=2.0.4" rel="stylesheet" />
-    <link href="./assets/css/modern.css" rel="stylesheet" />
-    <link href="./assets/css/navbar.css" rel="stylesheet" />
-    <link href="./assets/css/portal.css" rel="stylesheet" />
+  <link href="./assets/css/modern.css" rel="stylesheet" />
+  <link href="./assets/css/navbar.css" rel="stylesheet" />
+  <link href="./assets/css/portal.css" rel="stylesheet" />
+  <link href="./assets/css/sidebar.css" rel="stylesheet" />
   <link href="./assets/demo/demo.css" rel="stylesheet" />
   <style>
     .notification-form {
@@ -161,89 +162,13 @@
 <link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 
-<body class="landing-page sidebar-collapse">
-  <nav class="navbar main-navbar fixed-top navbar-expand-lg" color-on-scroll="100" id="sectionsNav">
-    <div class="container">
-      <div class="navbar-translate">
-        <a class="navbar-brand" href="instructorhome.php">Quiz Portal</a>
-        <button class="navbar-toggler" type="button" data-toggle="collapse" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="sr-only">Toggle navigation</span>
-          <span class="navbar-toggler-icon"></span>
-          <span class="navbar-toggler-icon"></span>
-          <span class="navbar-toggler-icon"></span>
-          <span class="navbar-toggler-icon"></span>
-        </button>
-      </div>
-      <div class="collapse navbar-collapse">
-        <ul class="navbar-nav mx-auto">
-          <li class="nav-item">
-            <a href="manage_classes_subjects.php" class="nav-link">
-              <i class="material-icons">school</i> Manage Classes & Subjects
-            </a>
-          </li>
-          <li class="nav-item">
-            <a href="questionfeed.php" class="nav-link">
-              <i class="material-icons">input</i> Feed Questions
-            </a>
-          </li>
-          <li class="nav-item">
-            <a href="view_questions.php" class="nav-link">
-              <i class="material-icons">list_alt</i> Questions Bank
-            </a>
-          </li>
-          <li class="nav-item">
-            <a href="quizconfig.php" class="nav-link">
-              <i class="material-icons">layers</i> Set Quiz
-            </a>
-          </li>
-          <li class="nav-item">
-            <a href="manage_quizzes.php" class="nav-link">
-              <i class="material-icons">settings</i> Manage Quizzes
-            </a>
-          </li>
-          <li class="nav-item">
-            <a href="view_quiz_results.php" class="nav-link">
-              <i class="material-icons">assessment</i> View Results
-            </a>
-          </li>
-          <li class="nav-item">
-            <a href="manage_instructors.php" class="nav-link">
-              <i class="material-icons">people</i> Manage Instructors
-            </a>
-          </li>
-          <li class="nav-item">
-            <a href="manage_students.php" class="nav-link">
-              <i class="material-icons">group</i> Manage Students
-            </a>
-          </li>
-          <li class="nav-item active">
-            <a href="manage_notifications.php" class="nav-link">
-              <i class="material-icons">notifications</i> Manage Notifications
-            </a>
-          </li>
-          <li class="nav-item">
-            <a href="my_profile.php" class="nav-link">
-              <i class="material-icons">person</i> My Profile
-            </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" rel="tooltip" title="" data-placement="bottom" href="instructorlogout.php" data-original-title="Get back to Login Page">
-              <i class="material-icons">power_settings_new</i> Log Out
-            </a>
-          </li>
-          <li class="nav-item d-flex align-items-center">
-            <div class="togglebutton mb-0">
-                <label class="m-0">
-                  <input type="checkbox" id="darkModeToggle">
-                  <span class="toggle"></span>
-                </label>
-              </div>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </nav>
-  
+<body class="dark-mode">
+<div class="layout">
+  <?php include './includes/sidebar.php'; ?>
+  <div class="main">
+    <?php include './includes/header.php'; ?>
+    <main class="content">
+    
   <div class="main main-raised" style="margin-top: 100px; min-height: calc(100vh - 300px);">
     <div class="container">
       <div class="section">
@@ -410,7 +335,10 @@
       </div>
     </div>
   </footer>
-  
+    </main>
+  </div>
+</div>
+
   <!--   Core JS Files   -->
   <script src="./assets/js/core/jquery.min.js" type="text/javascript"></script>
   <script src="./assets/js/core/popper.min.js" type="text/javascript"></script>
@@ -448,5 +376,6 @@
     });
   </script>
 <script src="./assets/js/dark-mode.js"></script>
+<script src="./assets/js/sidebar.js"></script>
 </body>
-</html> 
+</html>

--- a/code/manage_quizzes.php
+++ b/code/manage_quizzes.php
@@ -187,6 +187,7 @@ $conn->close();
     <link href="./assets/css/modern.css" rel="stylesheet" />
     <link href="./assets/css/navbar.css" rel="stylesheet" />
     <link href="./assets/css/portal.css" rel="stylesheet" />
+    <link href="./assets/css/sidebar.css" rel="stylesheet" />
     <style>
         /* Fixed Navbar Styles */
         .navbar {
@@ -331,89 +332,12 @@ $conn->close();
     </style>
 <link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
-<body class="landing-page sidebar-collapse">
-    <nav class="navbar main-navbar fixed-top navbar-expand-lg">
-        <div class="container">
-            <div class="navbar-translate">
-                <a class="navbar-brand" href="instructorhome.php">Quiz Portal</a>
-                <button class="navbar-toggler" type="button" data-toggle="collapse" aria-expanded="false" aria-label="Toggle navigation">
-                    <span class="sr-only">Toggle navigation</span>
-                    <span class="navbar-toggler-icon"></span>
-                    <span class="navbar-toggler-icon"></span>
-                    <span class="navbar-toggler-icon"></span>
-                    <span class="navbar-toggler-icon"></span>
-                </button>
-            </div>
-            <div class="collapse navbar-collapse">
-                <ul class="navbar-nav mx-auto">
-                    <li class="nav-item">
-                        <a href="manage_classes_subjects.php" class="nav-link">
-                            <i class="material-icons">school</i> Manage Classes & Subjects
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="questionfeed.php" class="nav-link">
-                            <i class="material-icons">input</i> Feed Questions
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="view_questions.php" class="nav-link">
-                            <i class="material-icons">list_alt</i> Questions Bank
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="quizconfig.php" class="nav-link">
-                            <i class="material-icons">layers</i> Set Quiz
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="manage_quizzes.php" class="nav-link">
-                            <i class="material-icons">settings</i> Manage Quizzes
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="view_quiz_results.php" class="nav-link">
-                            <i class="material-icons">assessment</i> View Results
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="manage_instructors.php" class="nav-link">
-                            <i class="material-icons">people</i> Manage Instructors
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="manage_students.php" class="nav-link">
-                            <i class="material-icons">group</i> Manage Students
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="manage_notifications.php" class="nav-link">
-                            <i class="material-icons">notifications</i> Manage Notifications
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="my_profile.php" class="nav-link">
-                            <i class="material-icons">person</i> My Profile
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" rel="tooltip" title="" data-placement="bottom" href="instructorlogout.php" data-original-title="Get back to Login Page">
-                            <i class="material-icons">power_settings_new</i> Log Out
-                        </a>
-                    </li>
-          <li class="nav-item d-flex align-items-center">
-            <div class="togglebutton mb-0">
-                <label class="m-0">
-                  <input type="checkbox" id="darkModeToggle">
-                  <span class="toggle"></span>
-                </label>
-              </div>
-          </li>
-                </ul>
-            </div>
-        </div>
-    </nav>
-
+<body class="dark-mode">
+<div class="layout">
+  <?php include './includes/sidebar.php'; ?>
+  <div class="main">
+    <?php include './includes/header.php'; ?>
+    <main class="content">
     <div class="wrapper">
         <div class="main main-raised">
             <div class="container">
@@ -525,6 +449,9 @@ $conn->close();
     </footer>
 
     </div> <!-- wrapper -->
+    </main>
+  </div>
+</div>
 
     <!--   Core JS Files   -->
     <script src="./assets/js/core/jquery.min.js" type="text/javascript"></script>
@@ -567,5 +494,6 @@ $conn->close();
         });
     </script>
 <script src="./assets/js/dark-mode.js"></script>
+<script src="./assets/js/sidebar.js"></script>
 </body>
-</html> 
+</html>

--- a/code/manage_students.php
+++ b/code/manage_students.php
@@ -311,6 +311,7 @@ $conn->close();
     <link href="./assets/css/modern.css" rel="stylesheet" />
     <link href="./assets/css/navbar.css" rel="stylesheet" />
     <link href="./assets/css/portal.css" rel="stylesheet" />
+    <link href="./assets/css/sidebar.css" rel="stylesheet" />
     <link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/css/select2.min.css" rel="stylesheet" />
     <style>
         /* Fixed Navbar Styles */
@@ -544,89 +545,12 @@ $conn->close();
     </style>
 <link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
-<body class="landing-page sidebar-collapse">
-    <nav class="navbar main-navbar fixed-top navbar-expand-lg">
-        <div class="container">
-            <div class="navbar-translate">
-                <a class="navbar-brand" href="instructorhome.php">Quiz Portal</a>
-                <button class="navbar-toggler" type="button" data-toggle="collapse" aria-expanded="false" aria-label="Toggle navigation">
-                    <span class="sr-only">Toggle navigation</span>
-                    <span class="navbar-toggler-icon"></span>
-                    <span class="navbar-toggler-icon"></span>
-                    <span class="navbar-toggler-icon"></span>
-                    <span class="navbar-toggler-icon"></span>
-                </button>
-            </div>
-            <div class="collapse navbar-collapse">
-                <ul class="navbar-nav mx-auto">
-                    <li class="nav-item">
-                        <a href="manage_classes_subjects.php" class="nav-link">
-                            <i class="material-icons">school</i> Manage Classes & Subjects
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="questionfeed.php" class="nav-link">
-                            <i class="material-icons">input</i> Feed Questions
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="view_questions.php" class="nav-link">
-                            <i class="material-icons">list_alt</i> Questions Bank
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="quizconfig.php" class="nav-link">
-                            <i class="material-icons">layers</i> Set Quiz
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="manage_quizzes.php" class="nav-link">
-                            <i class="material-icons">settings</i> Manage Quizzes
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="view_quiz_results.php" class="nav-link">
-                            <i class="material-icons">assessment</i> View Results
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="manage_instructors.php" class="nav-link">
-                            <i class="material-icons">people</i> Manage Instructors
-                        </a>
-                    </li>
-                            <li class="nav-item">
-                                <a href="manage_students.php" class="nav-link">
-                                    <i class="material-icons">group</i> Manage Students
-                                </a>
-                            </li>
-                            <li class="nav-item">
-                                <a href="manage_notifications.php" class="nav-link">
-                                    <i class="material-icons">notifications</i> Manage Notifications
-                                </a>
-                            </li>
-                            <li class="nav-item">
-                                <a href="my_profile.php" class="nav-link">
-                                    <i class="material-icons">person</i> My Profile
-                                </a>
-                            </li>
-                    <li class="nav-item">
-                        <a class="nav-link" rel="tooltip" title="" data-placement="bottom" href="instructorlogout.php" data-original-title="Get back to Login Page">
-                            <i class="material-icons">power_settings_new</i> Log Out
-                        </a>
-                    </li>
-          <li class="nav-item d-flex align-items-center">
-            <div class="togglebutton mb-0">
-                <label class="m-0">
-                  <input type="checkbox" id="darkModeToggle">
-                  <span class="toggle"></span>
-                </label>
-              </div>
-          </li>
-                </ul>
-            </div>
-        </div>
-    </nav>
-
+<body class="dark-mode">
+<div class="layout">
+  <?php include './includes/sidebar.php'; ?>
+  <div class="main">
+    <?php include './includes/header.php'; ?>
+    <main class="content">
     <div class="wrapper">
         <div class="main main-raised">
             <div class="container">
@@ -935,6 +859,9 @@ $conn->close();
             </div>
         </footer>
     </div>
+    </main>
+  </div>
+</div>
 
     <!--   Core JS Files   -->
     <script src="./assets/js/core/jquery.min.js" type="text/javascript"></script>
@@ -1297,5 +1224,6 @@ $conn->close();
         });
     </script>
 <script src="./assets/js/dark-mode.js"></script>
+<script src="./assets/js/sidebar.js"></script>
 </body>
-</html> 
+</html>

--- a/code/my_profile.php
+++ b/code/my_profile.php
@@ -91,6 +91,7 @@ $conn->close();
     <link href="./assets/css/modern.css" rel="stylesheet" />
     <link href="./assets/css/navbar.css" rel="stylesheet" />
     <link href="./assets/css/portal.css" rel="stylesheet" />
+    <link href="./assets/css/sidebar.css" rel="stylesheet" />
     <style>
         .navbar {
             transition: all 0.3s ease;
@@ -171,88 +172,13 @@ $conn->close();
     </style>
 <link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
-<body class="landing-page sidebar-collapse">
-    <nav class="navbar main-navbar fixed-top navbar-expand-lg">
-        <div class="container">
-            <div class="navbar-translate">
-                <a class="navbar-brand" href="instructorhome.php">Quiz Portal</a>
-                <button class="navbar-toggler" type="button" data-toggle="collapse" aria-expanded="false" aria-label="Toggle navigation">
-                    <span class="sr-only">Toggle navigation</span>
-                    <span class="navbar-toggler-icon"></span>
-                    <span class="navbar-toggler-icon"></span>
-                    <span class="navbar-toggler-icon"></span>
-                </button>
-            </div>
-            <div class="collapse navbar-collapse">
-                <ul class="navbar-nav mx-auto">
-                    <li class="nav-item">
-                        <a href="manage_classes_subjects.php" class="nav-link">
-                            <i class="material-icons">school</i> Manage Classes & Subjects
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="questionfeed.php" class="nav-link">
-                            <i class="material-icons">input</i> Feed Questions
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="view_questions.php" class="nav-link">
-                            <i class="material-icons">list_alt</i> Questions Bank
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="quizconfig.php" class="nav-link">
-                            <i class="material-icons">layers</i> Set Quiz
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="manage_quizzes.php" class="nav-link">
-                            <i class="material-icons">settings</i> Manage Quizzes
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="view_quiz_results.php" class="nav-link">
-                            <i class="material-icons">assessment</i> View Results
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="manage_instructors.php" class="nav-link">
-                            <i class="material-icons">people</i> Manage Instructors
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="manage_students.php" class="nav-link">
-                            <i class="material-icons">group</i> Manage Students
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="manage_notifications.php" class="nav-link">
-                            <i class="material-icons">notifications</i> Manage Notifications
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="my_profile.php" class="nav-link">
-                            <i class="material-icons">person</i> My Profile
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="instructorlogout.php">
-                            <i class="material-icons">power_settings_new</i> Log Out
-                        </a>
-                    </li>
-          <li class="nav-item d-flex align-items-center">
-            <div class="togglebutton mb-0">
-                <label class="m-0">
-                  <input type="checkbox" id="darkModeToggle">
-                  <span class="toggle"></span>
-                </label>
-              </div>
-          </li>
-                </ul>
-            </div>
-        </div>
-    </nav>
-
+<body class="dark-mode">
+<div class="layout">
+  <?php include './includes/sidebar.php'; ?>
+  <div class="main">
+    <?php include './includes/header.php'; ?>
+    <main class="content">
+    
     <div class="wrapper">
         <div class="main main-raised">
             <div class="container">
@@ -329,6 +255,9 @@ $conn->close();
             </div>
         </footer>
     </div>
+    </main>
+  </div>
+</div>
 
     <!--   Core JS Files   -->
     <script src="./assets/js/core/jquery.min.js" type="text/javascript"></script>
@@ -337,5 +266,6 @@ $conn->close();
     <script src="./assets/js/plugins/moment.min.js"></script>
     <script src="./assets/js/material-kit.js?v=2.0.4" type="text/javascript"></script>
 <script src="./assets/js/dark-mode.js"></script>
+<script src="./assets/js/sidebar.js"></script>
 </body>
-</html> 
+</html>

--- a/code/quizconfig.php
+++ b/code/quizconfig.php
@@ -748,9 +748,10 @@ function saveSelectedQuestions() {
   <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Roboto+Slab:400,700|Material+Icons" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link href="./assets/css/material-kit.css?v=2.0.4" rel="stylesheet" />
-    <link href="./assets/css/modern.css" rel="stylesheet" />
-    <link href="./assets/css/navbar.css" rel="stylesheet" />
-    <link href="./assets/css/portal.css" rel="stylesheet" />
+  <link href="./assets/css/modern.css" rel="stylesheet" />
+  <link href="./assets/css/navbar.css" rel="stylesheet" />
+  <link href="./assets/css/portal.css" rel="stylesheet" />
+  <link href="./assets/css/sidebar.css" rel="stylesheet" />
   <link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/css/select2.min.css" rel="stylesheet" />
   <style>
     /* Fixed Navbar Styles are defined globally in navbar.css */
@@ -1065,89 +1066,12 @@ function saveSelectedQuestions() {
 <link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
 
-<body class="landing-page sidebar-collapse">
-  <nav class="navbar main-navbar fixed-top navbar-expand-lg">
-    <div class="container">
-      <div class="navbar-translate">
-        <a class="navbar-brand" href="instructorhome.php">Quiz Portal</a>
-        <button class="navbar-toggler" type="button" data-toggle="collapse" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="sr-only">Toggle navigation</span>
-          <span class="navbar-toggler-icon"></span>
-          <span class="navbar-toggler-icon"></span>
-          <span class="navbar-toggler-icon"></span>
-          <span class="navbar-toggler-icon"></span>
-        </button>
-      </div>
-      <div class="collapse navbar-collapse">
-        <ul class="navbar-nav mx-auto">
-          <li class="nav-item">
-            <a href="manage_classes_subjects.php" class="nav-link">
-              <i class="material-icons">school</i> Manage Classes & Subjects
-            </a>
-          </li>
-          <li class="nav-item">
-            <a href="questionfeed.php" class="nav-link">
-              <i class="material-icons">input</i> Feed Questions
-            </a>
-          </li>
-          <li class="nav-item">
-            <a href="view_questions.php" class="nav-link">
-              <i class="material-icons">list_alt</i> Questions Bank
-            </a>
-          </li>
-          <li class="nav-item">
-            <a href="quizconfig.php" class="nav-link">
-              <i class="material-icons">layers</i> Set Quiz
-            </a>
-          </li>
-          <li class="nav-item">
-            <a href="manage_quizzes.php" class="nav-link">
-              <i class="material-icons">settings</i> Manage Quizzes
-            </a>
-          </li>
-          <li class="nav-item">
-            <a href="view_quiz_results.php" class="nav-link">
-              <i class="material-icons">assessment</i> View Results
-            </a>
-          </li>
-          <li class="nav-item">
-            <a href="manage_instructors.php" class="nav-link">
-              <i class="material-icons">people</i> Manage Instructors
-            </a>
-          </li>
-                    <li class="nav-item">
-                        <a href="manage_students.php" class="nav-link">
-                            <i class="material-icons">group</i> Manage Students
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="manage_notifications.php" class="nav-link">
-                            <i class="material-icons">notifications</i> Manage Notifications
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="my_profile.php" class="nav-link">
-                            <i class="material-icons">person</i> My Profile
-                        </a>
-                    </li>
-          <li class="nav-item">
-            <a class="nav-link" rel="tooltip" title="" data-placement="bottom" href="instructorlogout.php" data-original-title="Get back to Login Page">
-              <i class="material-icons">power_settings_new</i> Log Out
-            </a>
-          </li>
-          <li class="nav-item d-flex align-items-center">
-            <div class="togglebutton mb-0">
-                <label class="m-0">
-                  <input type="checkbox" id="darkModeToggle">
-                  <span class="toggle"></span>
-                </label>
-              </div>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </nav>
-
+<body class="dark-mode">
+<div class="layout">
+  <?php include './includes/sidebar.php'; ?>
+  <div class="main">
+    <?php include './includes/header.php'; ?>
+    <main class="content">
   <div class="wrapper">
     <div class="main main-raised">
       <div class="container">
@@ -2053,8 +1977,11 @@ function saveSelectedQuestions() {
       </div>
     </div>
   </div>
-</footer>
-</div> <!-- wrapper -->
+ </footer>
+ </div> <!-- wrapper -->
+    </main>
+  </div>
+</div>
 
   <!-- Core JS Files -->
   <script src="./assets/js/core/jquery.min.js" type="text/javascript"></script>
@@ -2133,5 +2060,6 @@ function saveSelectedQuestions() {
     });
   </script>
 <script src="./assets/js/dark-mode.js"></script>
+<script src="./assets/js/sidebar.js"></script>
 </body>
 </html>

--- a/code/view_quiz_results.php
+++ b/code/view_quiz_results.php
@@ -201,6 +201,7 @@ $conn->close();
     <link href="./assets/css/modern.css" rel="stylesheet" />
     <link href="./assets/css/navbar.css" rel="stylesheet" />
     <link href="./assets/css/portal.css" rel="stylesheet" />
+    <link href="./assets/css/sidebar.css" rel="stylesheet" />
     <style>
         /* Fixed Navbar Styles */
         .navbar {
@@ -331,89 +332,12 @@ $conn->close();
     </style>
 <link id="dark-mode-style" rel="stylesheet" href="./assets/css/dark-mode.css" />
 </head>
-<body class="landing-page sidebar-collapse">
-    <nav class="navbar main-navbar fixed-top navbar-expand-lg">
-        <div class="container">
-            <div class="navbar-translate">
-                <a class="navbar-brand" href="instructorhome.php">Quiz Portal</a>
-                <button class="navbar-toggler" type="button" data-toggle="collapse" aria-expanded="false" aria-label="Toggle navigation">
-                    <span class="sr-only">Toggle navigation</span>
-                    <span class="navbar-toggler-icon"></span>
-                    <span class="navbar-toggler-icon"></span>
-                    <span class="navbar-toggler-icon"></span>
-                    <span class="navbar-toggler-icon"></span>
-                </button>
-            </div>
-            <div class="collapse navbar-collapse">
-                <ul class="navbar-nav mx-auto">
-                    <li class="nav-item">
-                        <a href="manage_classes_subjects.php" class="nav-link">
-                            <i class="material-icons">school</i> Manage Classes & Subjects
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="questionfeed.php" class="nav-link">
-                            <i class="material-icons">input</i> Feed Questions
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="view_questions.php" class="nav-link">
-                            <i class="material-icons">list_alt</i> Questions Bank
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="quizconfig.php" class="nav-link">
-                            <i class="material-icons">layers</i> Set Quiz
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="manage_quizzes.php" class="nav-link">
-                            <i class="material-icons">settings</i> Manage Quizzes
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="view_quiz_results.php" class="nav-link">
-                            <i class="material-icons">assessment</i> View Results
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="manage_instructors.php" class="nav-link">
-                            <i class="material-icons">people</i> Manage Instructors
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="manage_students.php" class="nav-link">
-                            <i class="material-icons">group</i> Manage Students
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="manage_notifications.php" class="nav-link">
-                            <i class="material-icons">notifications</i> Manage Notifications
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a href="my_profile.php" class="nav-link">
-                            <i class="material-icons">person</i> My Profile
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" rel="tooltip" title="" data-placement="bottom" href="instructorlogout.php" data-original-title="Get back to Login Page">
-                            <i class="material-icons">power_settings_new</i> Log Out
-                        </a>
-                    </li>
-          <li class="nav-item d-flex align-items-center">
-            <div class="togglebutton mb-0">
-                <label class="m-0">
-                  <input type="checkbox" id="darkModeToggle">
-                  <span class="toggle"></span>
-                </label>
-              </div>
-          </li>
-                </ul>
-            </div>
-        </div>
-    </nav>
-
+<body class="dark-mode">
+<div class="layout">
+  <?php include './includes/sidebar.php'; ?>
+  <div class="main">
+    <?php include './includes/header.php'; ?>
+    <main class="content">
     <div class="wrapper">
         <div class="main main-raised">
             <div class="container">
@@ -475,6 +399,9 @@ $conn->close();
             </div>
         </footer>
     </div>
+    </main>
+  </div>
+</div>
 
     <!--   Core JS Files   -->
     <script src="./assets/js/core/jquery.min.js" type="text/javascript"></script>
@@ -532,5 +459,6 @@ $conn->close();
         });
     });
     </script>
+<script src="./assets/js/sidebar.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Adopt shared sidebar and header layout on instructor management pages
- Remove legacy navbar markup and include new sidebar assets

## Testing
- `php -l code/quizconfig.php`
- `php -l code/manage_quizzes.php`
- `php -l code/view_quiz_results.php`
- `php -l code/manage_instructors.php`
- `php -l code/manage_students.php`
- `php -l code/manage_notifications.php`
- `php -l code/my_profile.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5eb9d0290832ca6760d605df6a6de