### PR TITLE
Refine sidebar spacing and eliminate top border

### DIFF
--- a/code/assets/css/sidebar.css
+++ b/code/assets/css/sidebar.css
@@ -1,5 +1,5 @@
 /* Dark sidebar layout for dashboard pages */
-body {
+html, body {
     margin: 0;
     font-family: 'Inter', sans-serif;
     background: #121212;
@@ -18,6 +18,7 @@ body {
     display: flex;
     flex-direction: column;
     transition: width 0.3s ease, transform 0.3s ease;
+    border: none;
 }
 
 .sidebar .logo {
@@ -38,7 +39,7 @@ body {
 .sidebar li a {
     display: flex;
     align-items: center;
-    padding: 12px 20px;
+    padding: 8px 20px;
     color: #ccc;
     text-decoration: none;
     transition: background 0.2s;
@@ -90,6 +91,7 @@ body {
     align-items: center;
     justify-content: flex-end;
     padding: 10px 20px;
+    border: none;
 }
 
 .header .toggle-sidebar {


### PR DESCRIPTION
## Summary
- Compact sidebar navigation by reducing link padding
- Remove stray top border by unifying page background and stripping sidebar/header borders

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b67078c3bc832ca4a8a013f2fe9fff