### PR TITLE
Ensure mobile sidebar toggle works across pages

### DIFF
--- a/code/assets/css/sidebar.css
+++ b/code/assets/css/sidebar.css
@@ -148,6 +148,7 @@ html, body {
         top: 0;
         height: 100%;
         transform: translateX(-100%);
+        z-index: 1001;
     }
     .sidebar.open {
         transform: translateX(0);

--- a/code/assets/js/sidebar.js
+++ b/code/assets/js/sidebar.js
@@ -1,9 +1,9 @@
-document.addEventListener('DOMContentLoaded', function () {
+(function () {
   var toggles = document.querySelectorAll('.toggle-sidebar');
   var sidebar = document.querySelector('.sidebar');
   if (!toggles.length || !sidebar) return;
 
-  Array.prototype.forEach.call(toggles, function (toggle) {
+  toggles.forEach(function (toggle) {
     toggle.addEventListener('click', function () {
       if (window.innerWidth <= 768) {
         sidebar.classList.toggle('open');
@@ -12,4 +12,4 @@ document.addEventListener('DOMContentLoaded', function () {
       }
     });
   });
-});
+})();


### PR DESCRIPTION
## Summary
- raise sidebar z-index on mobile so it overlays content
- simplify sidebar toggle script to run on all pages without DOMContentLoaded dependency

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b610c7b8832c962ad7d6bcd84eab