### PR TITLE
Remove headings and tighten layout on instructor pages

### DIFF
--- a/code/manage_instructors.php
+++ b/code/manage_instructors.php
@@ -97,11 +97,8 @@ $conn->close();
     <?php include './includes/header.php'; ?>
     <main class="content">
     <div class="wrapper">
-        <div class="main main-raised">
+        <div class="main main-raised" style="margin-top: 0;">
             <div class="container">
-                <div class="section text-center">
-                    <h2 class="title">Manage Instructors</h2>
-                </div>
                 <div class="section">
                     <div class="row">
                         <div class="col-md-8 ml-auto mr-auto">

--- a/code/manage_notifications.php
+++ b/code/manage_notifications.php
@@ -114,12 +114,11 @@
     <?php include './includes/header.php'; ?>
     <main class="content">
     
-  <div class="main main-raised" style="margin-top: 100px; min-height: calc(100vh - 300px);">
+  <div class="main main-raised" style="margin-top: 0; min-height: calc(100vh - 300px);">
     <div class="container">
       <div class="section">
         <div class="row">
           <div class="col-md-12 text-center">
-            <h2 class="title">Manage Notifications</h2>
             <p class="description">Send important notifications to students based on class and section</p>
           </div>
         </div>

--- a/code/manage_students.php
+++ b/code/manage_students.php
@@ -438,11 +438,8 @@ $conn->close();
     <?php include './includes/header.php'; ?>
     <main class="content">
     <div class="wrapper">
-        <div class="main main-raised">
+        <div class="main main-raised" style="margin-top: 0;">
             <div class="container">
-                <div class="section text-center">
-                    <h2 class="title">Manage Students</h2>
-                </div>
                 <div class="section">
                     <?php echo $message; ?>
                     

--- a/code/my_profile.php
+++ b/code/my_profile.php
@@ -103,11 +103,8 @@ $conn->close();
     <main class="content">
     
     <div class="wrapper">
-        <div class="main main-raised">
+        <div class="main main-raised" style="margin-top: 0;">
             <div class="container">
-                <div class="section text-center">
-                    <h2 class="title">My Profile</h2>
-                </div>
                 <div class="section">
                     <div class="row">
                         <div class="col-md-8 ml-auto mr-auto">


### PR DESCRIPTION
## Summary
- Drop redundant "My Profile" heading and pull content to top of page
- Remove "Manage Notifications" title and lift container to the top
- Remove "Manage Students" and "Manage Instructors" headings and shift their forms upward

## Testing
- `php -l code/my_profile.php`
- `php -l code/manage_notifications.php`
- `php -l code/manage_students.php`
- `php -l code/manage_instructors.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6fb1047d8832c802c0058b87b7c28