### PR TITLE
Fix question feed height for mobile screens

### DIFF
--- a/code/questionfeed.php
+++ b/code/questionfeed.php
@@ -614,6 +614,7 @@ function getChapters($conn, $class_id, $subject_id) {
         background-color: #11111a !important;
         margin-top: 0;
         padding-top: 80px;
+        height: auto !important;
         min-height: calc(100vh - 80px);
       }
 


### PR DESCRIPTION
## Summary
- Allow question feed to expand beyond the viewport on mobile by overriding Material Kit's fixed `height: 100vh`

## Testing
- `php -l code/questionfeed.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b719bd7764832c8650d9776c4dfb76