### PR TITLE
Fix sidebar toggle on results page

### DIFF
--- a/code/my_results.php
+++ b/code/my_results.php
@@ -149,6 +149,7 @@ $results = $stmt->get_result();
 <script src="./assets/js/plugins/nouislider.min.js" type="text/javascript"></script>
 <script src="./assets/js/material-kit.js?v=2.0.4" type="text/javascript"></script>
 <script src="./assets/js/dark-mode.js"></script>
+<script src="./assets/js/sidebar.js"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- load sidebar.js on `my_results.php` so the sidebar toggle works in mobile view

## Testing
- `php -l code/my_results.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b72d879e04832ca8acc6a6281d3c0a