### PR TITLE
Make student login footer designer text white

### DIFF
--- a/code/studentlogin.php
+++ b/code/studentlogin.php
@@ -214,6 +214,7 @@ $conn->close();
         .footer .copyright .designer {
             font-style: italic;
             margin: 5px 0;
+            color: white;
         }
         
         .footer .copyright .year {


### PR DESCRIPTION
## Summary
- ensure designer attribution in student login footer uses white text for better contrast

## Testing
- `php -l code/studentlogin.php`


------
https://chatgpt.com/codex/tasks/task_e_68b8159244b8832cbacdfd12e43f68ee