### PR TITLE
fix: remove login footer gap

### DIFF
--- a/code/studentlogin.php
+++ b/code/studentlogin.php
@@ -226,6 +226,14 @@ $conn->close();
             width: 100%;
             margin-top: auto;
         }
+
+        /* Override Material Kit's absolute positioned footer on login pages */
+        .login-page .footer {
+            position: relative;
+            background: #ffffff;
+            color: #555;
+            z-index: auto;
+        }
         
         .footer .copyright {
             color: #555;


### PR DESCRIPTION
## Summary
- override Material Kit's login page footer styles to keep footer in normal flow and remove stray border

## Testing
- `php -l code/studentlogin.php`
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b81794a270832c88a37db6f6ea8203