### PR TITLE
Set student login footer credit text to black

### DIFF
--- a/code/studentlogin.php
+++ b/code/studentlogin.php
@@ -250,7 +250,7 @@ $conn->close();
         .footer .copyright .designer {
             font-style: italic;
             margin: 5px 0;
-            color: white;
+            color: black;
         }
         
         .footer .copyright .year {


### PR DESCRIPTION
## Summary
- make designer credit on student login page use black text

## Testing
- `php -l code/studentlogin.php`


------
https://chatgpt.com/codex/tasks/task_e_68b819e42be8832cb91f0915c8dc3233