### PR TITLE
Add Monolog logging with rotation and configurable levels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ request_audit.log
 /android/app/build/
 /android/build/
 code/node_modules/
+code/vendor/
+code/logs/
 .env

--- a/code/composer.json
+++ b/code/composer.json
@@ -5,7 +5,8 @@
     "require": {
         "php": ">=7.2",
         "mpdf/mpdf": "^8.1",
-        "vlucas/phpdotenv": "^5.5"
+        "vlucas/phpdotenv": "^5.5",
+        "monolog/monolog": "^2.9"
     },
     "autoload": {
         "psr-4": {

--- a/code/composer.lock
+++ b/code/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e1d288e6fe78c4b52304c110b33c5a33",
+    "content-hash": "1c744df70af33ffafb5af0333db6e7c9",
     "packages": [
         {
             "name": "graham-campbell/result-type",
@@ -67,6 +67,108 @@
                 }
             ],
             "time": "2024-07-20T21:45:45+00:00"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "5cf826f2991858b54d5c3809bee745560a1042a7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/5cf826f2991858b54d5c3809bee745560a1042a7",
+                "reference": "5cf826f2991858b54d5c3809bee745560a1042a7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2@dev",
+                "guzzlehttp/guzzle": "^7.4",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "phpspec/prophecy": "^1.15",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^8.5.38 || ^9.6.19",
+                "predis/predis": "^1.1 || ^2.0",
+                "rollbar/rollbar": "^1.3 || ^2 || ^3",
+                "ruflin/elastica": "^7",
+                "swiftmailer/swiftmailer": "^5.3|^6.0",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/2.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-12T12:43:37+00:00"
         },
         {
             "name": "mpdf/mpdf",

--- a/code/database.php
+++ b/code/database.php
@@ -18,6 +18,8 @@ if (file_exists($autoload)) {
     }
 }
 
+require_once __DIR__ . '/logger.php';
+
 $db_host = $_ENV['DB_HOST'] ?? 'localhost';
 $db_name = $_ENV['DB_NAME'] ?? 'database';
 $db_user = $_ENV['DB_USER'] ?? 'username';
@@ -31,27 +33,27 @@ $conn = null;
 try {
     $conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
 } catch (mysqli_sql_exception $e) {
-    error_log('Database Connection Failed: ' . $e->getMessage(), 3, 'quiz_errors.log');
+    $logger->error('Database Connection Failed: ' . $e->getMessage());
     $conn = null;
 }
 
 // If the connection object exists but has an error, log it without producing
 // any output that could corrupt API responses.
 if ($conn && $conn->connect_error) {
-    error_log('Database Connection Failed: ' . $conn->connect_error, 3, 'quiz_errors.log');
+    $logger->error('Database Connection Failed: ' . $conn->connect_error);
 }
 
 if ($conn) {
     // Ensure the connection uses UTF-8 so JSON encoding doesn't fail on
     // characters stored with a different encoding in the database.
     if (!$conn->set_charset('utf8mb4')) {
-        error_log('Failed to set database connection charset: ' . $conn->error, 3, 'quiz_errors.log');
+        $logger->warning('Failed to set database connection charset: ' . $conn->error);
     }
 
     // Set session timezone to match PHP timezone
     if (!$conn->query("SET time_zone = '+05:00'")) { // Replace +05:00 with your timezone offset
         // Failed to set timezone, log error.
-        error_log('Failed to set database session timezone: ' . $conn->error, 3, 'quiz_errors.log');
+        $logger->warning('Failed to set database session timezone: ' . $conn->error);
     }
 
     // Set session variables for timezone

--- a/code/logger.php
+++ b/code/logger.php
@@ -1,0 +1,26 @@
+<?php
+use Monolog\Logger;
+use Monolog\Handler\RotatingFileHandler;
+
+$autoload = __DIR__ . '/vendor/autoload.php';
+if (file_exists($autoload)) {
+    require_once $autoload;
+}
+
+$logDir = __DIR__ . '/logs';
+if (!is_dir($logDir)) {
+    mkdir($logDir, 0777, true);
+}
+
+$env = $_ENV['APP_ENV'] ?? 'production';
+$levelName = $_ENV['LOG_LEVEL'] ?? ($env === 'production' ? 'WARNING' : 'DEBUG');
+$level = Logger::toMonologLevel($levelName);
+if ($env === 'production' && $level < Logger::WARNING) {
+    $level = Logger::WARNING;
+}
+
+$handler = new RotatingFileHandler($logDir . '/app.log', 30, $level, true);
+$handler->setFilenameFormat('{date}-{filename}', 'Y-m-d');
+
+$logger = new Logger('quizapp');
+$logger->pushHandler($handler);


### PR DESCRIPTION
## Summary
- add Monolog dependency and logging bootstrap with rotating files
- route database and question APIs through centralized logger
- ignore vendor and log folders

## Testing
- `composer update monolog/monolog`
- `php -l code/logger.php`
- `php -l code/database.php`
- `php -l code/get_questions.php`


------
https://chatgpt.com/codex/tasks/task_e_68b927d69eec832c8d23542e6fdb07e3