### PR TITLE
Fix topic input field overlap on desktop

### DIFF
--- a/code/manage_classes_subjects.php
+++ b/code/manage_classes_subjects.php
@@ -1044,7 +1044,7 @@ $stmt->close();
                                     <form class="add-form" method="post">
                                         <input type="hidden" name="action" value="add_topic">
                                         <div class="row">
-                                            <div class="col-md-3">
+                                            <div class="col-md-3 col-lg-2">
                                                 <select class="form-control" name="class_id" id="add-topic-class" required aria-label="Select class" title="Select class">
                                                     <option value="">Select Class</option>
                                                     <?php foreach ($classes as $class): ?>
@@ -1052,12 +1052,12 @@ $stmt->close();
                                                     <?php endforeach; ?>
                                                 </select>
                                             </div>
-                                            <div class="col-md-3">
+                                            <div class="col-md-3 col-lg-3">
                                                 <select class="form-control" name="subject_id" id="add-topic-subject" required aria-label="Select subject" title="Select subject">
                                                     <option value="">Select Subject</option>
                                                 </select>
                                             </div>
-                                            <div class="col-md-3 col-lg-3">
+                                            <div class="col-md-3 col-lg-4">
                                                 <select class="form-control" name="chapter_id" id="add-topic-chapter" required aria-label="Select chapter" title="Select chapter">
                                                     <option value="">Select Chapter</option>
                                                 </select>

--- a/code/manage_classes_subjects.php
+++ b/code/manage_classes_subjects.php
@@ -1057,12 +1057,12 @@ $stmt->close();
                                                     <option value="">Select Subject</option>
                                                 </select>
                                             </div>
-                                            <div class="col-md-3 col-lg-2">
+                                            <div class="col-md-3 col-lg-3">
                                                 <select class="form-control" name="chapter_id" id="add-topic-chapter" required aria-label="Select chapter" title="Select chapter">
                                                     <option value="">Select Chapter</option>
                                                 </select>
                                             </div>
-                                            <div class="col-md-3 col-lg-4">
+                                            <div class="col-md-3 col-lg-3">
                                                 <input type="text" class="form-control" name="topic_name" placeholder="Enter topic name" required>
                                                 <button type="submit" class="btn btn-primary mt-2">Add Topic</button>
                                             </div>

--- a/code/manage_classes_subjects.php
+++ b/code/manage_classes_subjects.php
@@ -1063,12 +1063,8 @@ $stmt->close();
                                                 </select>
                                             </div>
                                             <div class="col-md-3 col-lg-4">
-                                                <div class="input-group">
-                                                    <input type="text" class="form-control" name="topic_name" placeholder="Enter topic name" required>
-                                                    <div class="input-group-append">
-                                                        <button type="submit" class="btn btn-primary">Add Topic</button>
-                                                    </div>
-                                                </div>
+                                                <input type="text" class="form-control" name="topic_name" placeholder="Enter topic name" required>
+                                                <button type="submit" class="btn btn-primary mt-2">Add Topic</button>
                                             </div>
                                         </div>
                                     </form>

--- a/code/manage_classes_subjects.php
+++ b/code/manage_classes_subjects.php
@@ -1057,12 +1057,12 @@ $stmt->close();
                                                     <option value="">Select Subject</option>
                                                 </select>
                                             </div>
-                                            <div class="col-md-3">
+                                            <div class="col-md-3 col-lg-2">
                                                 <select class="form-control" name="chapter_id" id="add-topic-chapter" required aria-label="Select chapter" title="Select chapter">
                                                     <option value="">Select Chapter</option>
                                                 </select>
                                             </div>
-                                            <div class="col-md-3">
+                                            <div class="col-md-3 col-lg-4">
                                                 <div class="input-group">
                                                     <input type="text" class="form-control" name="topic_name" placeholder="Enter topic name" required>
                                                     <div class="input-group-append">


### PR DESCRIPTION
## Summary
- adjust desktop layout in `manage_classes_subjects.php` so the Topic name field remains visible next to the Add Topic button

## Testing
- `php -l code/manage_classes_subjects.php`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8ccf1318832c8d9a213149b3a2a7