### PR TITLE
Add paper generation page with PDF export

### DIFF
--- a/code/generate_paper.php
+++ b/code/generate_paper.php
@@ -1,0 +1,75 @@
+<?php
+session_start();
+if (!isset($_SESSION['paperloggedin']) || $_SESSION['paperloggedin'] !== true) {
+    header('Location: paper_login.php');
+    exit;
+}
+require_once __DIR__ . '/vendor/autoload.php';
+include 'database.php';
+
+$paperName = trim($_POST['paper_name'] ?? 'Question Paper');
+$subjectId = intval($_POST['subject_id'] ?? 0);
+$chapterId = intval($_POST['chapter_id'] ?? 0);
+$topicId = isset($_POST['topic_id']) && $_POST['topic_id'] !== '' ? intval($_POST['topic_id']) : null;
+$mcq = intval($_POST['mcq'] ?? 0);
+$short = intval($_POST['short'] ?? 0);
+$essay = intval($_POST['essay'] ?? 0);
+$fill = intval($_POST['fill'] ?? 0);
+$numerical = intval($_POST['numerical'] ?? 0);
+$paperDate = trim($_POST['paper_date'] ?? '');
+$logo = $_SESSION['paper_logo'];
+$header = $_SESSION['paper_header'];
+
+function fetch_questions($conn, $table, $fields, $chapterId, $topicId, $limit) {
+    if ($limit <= 0) return [];
+    $sql = "SELECT $fields FROM $table WHERE chapter_id=?";
+    $types = 'i';
+    $params = [$chapterId];
+    if ($topicId) { $sql .= " AND topic_id=?"; $types .= 'i'; $params[] = $topicId; }
+    $sql .= " ORDER BY RAND() LIMIT ?"; $types .= 'i'; $params[] = $limit;
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param($types, ...$params);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    $qs = [];
+    while($row = $res->fetch_assoc()) { $qs[] = $row; }
+    $stmt->close();
+    return $qs;
+}
+
+$sections = [];
+$sections['MCQs'] = fetch_questions($conn, 'mcqdb', 'question, optiona, optionb, optionc, optiond', $chapterId, $topicId, $mcq);
+$sections['Short Questions'] = fetch_questions($conn, 'shortanswer', 'question', $chapterId, $topicId, $short);
+$sections['Long Questions'] = fetch_questions($conn, 'essay', 'question', $chapterId, $topicId, $essay);
+$sections['Fill in the Blanks'] = fetch_questions($conn, 'fillintheblanks', 'question', $chapterId, $topicId, $fill);
+$sections['Numerical'] = fetch_questions($conn, 'numericaldb', 'question', $chapterId, $topicId, $numerical);
+$conn->close();
+
+$html = '<div style="text-align:center;">';
+if ($logo) $html .= '<img src="'.htmlspecialchars($logo).'" height="80"><br>';
+$html .= '<h2>'.htmlspecialchars($header).'</h2>';
+$html .= '<h3>'.htmlspecialchars($paperName).'</h3>';
+if ($paperDate) $html .= '<div>Date: '.htmlspecialchars($paperDate).'</div>';
+$html .= '</div>';
+
+foreach ($sections as $title => $questions) {
+    if (count($questions) === 0) continue;
+    $html .= '<h4>'.htmlspecialchars($title).'</h4><ol>';
+    foreach ($questions as $q) {
+        if ($title === 'MCQs') {
+            $html .= '<li>'.htmlspecialchars($q['question']).'<br>';
+            $html .= 'A. '.htmlspecialchars($q['optiona']).'<br>';
+            $html .= 'B. '.htmlspecialchars($q['optionb']).'<br>';
+            $html .= 'C. '.htmlspecialchars($q['optionc']).'<br>';
+            $html .= 'D. '.htmlspecialchars($q['optiond']).'</li>';
+        } else {
+            $html .= '<li>'.htmlspecialchars($q['question']).'</li>';
+        }
+    }
+    $html .= '</ol>';
+}
+
+$mpdf = new \Mpdf\Mpdf();
+$mpdf->WriteHTML($html);
+$mpdf->Output('paper.pdf', 'I');
+?>

--- a/code/paper_home.php
+++ b/code/paper_home.php
@@ -1,0 +1,50 @@
+<?php
+session_start();
+if (!isset($_SESSION['paperloggedin']) || $_SESSION['paperloggedin'] !== true) {
+    header('Location: paper_login.php');
+    exit;
+}
+include 'database.php';
+$subjects = $conn->query("SELECT subject_id, subject_name FROM subjects ORDER BY subject_name");
+$chapters = $conn->query("SELECT chapter_id, chapter_name FROM chapters ORDER BY chapter_name");
+$topics   = $conn->query("SELECT topic_id, topic_name FROM topics ORDER BY topic_name");
+$conn->close();
+$logo = $_SESSION['paper_logo'];
+$header = $_SESSION['paper_header'];
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Generate Paper</title>
+</head>
+<body>
+<?php if ($logo) { echo '<div style="text-align:center;"><img src="' . htmlspecialchars($logo) . '" height="80"></div>'; } ?>
+<h2 style="text-align:center;"><?php echo htmlspecialchars($header); ?></h2>
+<form method="post" action="generate_paper.php">
+    <label>Paper Name: <input type="text" name="paper_name" required></label><br>
+    <label>Select Subject: <select name="subject_id">
+        <?php while($row = $subjects->fetch_assoc()) { echo '<option value="'.$row['subject_id'].'">'.htmlspecialchars($row['subject_name']).'</option>'; } ?>
+    </select></label><br>
+    <label>Select Chapter: <select name="chapter_id">
+        <?php while($row = $chapters->fetch_assoc()) { echo '<option value="'.$row['chapter_id'].'">'.htmlspecialchars($row['chapter_name']).'</option>'; } ?>
+    </select></label><br>
+    <label>Select Topic: <select name="topic_id">
+        <option value="">Any</option>
+        <?php while($row = $topics->fetch_assoc()) { echo '<option value="'.$row['topic_id'].'">'.htmlspecialchars($row['topic_name']).'</option>'; } ?>
+    </select></label><br>
+    <label>MCQs: <input type="number" name="mcq" value="0" min="0"></label><br>
+    <label>Short Questions: <input type="number" name="short" value="0" min="0"></label><br>
+    <label>Long Questions: <input type="number" name="essay" value="0" min="0"></label><br>
+    <label>Fill in the Blanks: <input type="number" name="fill" value="0" min="0"></label><br>
+    <label>Numerical: <input type="number" name="numerical" value="0" min="0"></label><br>
+    <label>Date (optional): <input type="date" name="paper_date"></label><br>
+    <label>Selection Mode:
+        <input type="radio" name="mode" value="random" checked> Random
+        <input type="radio" name="mode" value="manual"> Manual
+    </label><br>
+    <button type="submit">Generate Paper</button>
+</form>
+<a href="paper_logout.php">Logout</a>
+</body>
+</html>

--- a/code/paper_login.php
+++ b/code/paper_login.php
@@ -1,0 +1,60 @@
+<?php
+session_start();
+
+if (isset($_SESSION['paperloggedin']) && $_SESSION['paperloggedin'] === true) {
+    header('Location: paper_home.php');
+    exit;
+}
+
+$login_error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    include 'database.php';
+    $email = trim($_POST['email'] ?? '');
+    $password = trim($_POST['password'] ?? '');
+    if ($email !== '' && $password !== '') {
+        $stmt = $conn->prepare('SELECT id, name, password, logo, header, activated_on, expires_on, is_active FROM paper_users WHERE email = ? AND password = ?');
+        if ($stmt) {
+            $stmt->bind_param('ss', $email, $password);
+            $stmt->execute();
+            $result = $stmt->get_result();
+            if ($user = $result->fetch_assoc()) {
+                $today = date('Y-m-d');
+                if ((!empty($user['activated_on']) && $today < $user['activated_on']) ||
+                    (!empty($user['expires_on']) && $today > $user['expires_on']) ||
+                    !$user['is_active']) {
+                    $login_error = 'Account inactive. Please contact administrator.';
+                } else {
+                    $_SESSION['paperloggedin'] = true;
+                    $_SESSION['paper_user_id'] = $user['id'];
+                    $_SESSION['paper_logo'] = $user['logo'];
+                    $_SESSION['paper_header'] = $user['header'];
+                    header('Location: paper_home.php');
+                    exit;
+                }
+            } else {
+                $login_error = 'Invalid credentials';
+            }
+            $stmt->close();
+        }
+        $conn->close();
+    } else {
+        $login_error = 'Please enter email and password';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Paper Generator Login</title>
+</head>
+<body>
+    <h2>Paper Generator Login</h2>
+    <?php if ($login_error) echo '<p style="color:red;">' . htmlspecialchars($login_error) . '</p>'; ?>
+    <form method="post">
+        <label>Email: <input type="email" name="email" required></label><br>
+        <label>Password: <input type="password" name="password" required></label><br>
+        <button type="submit">Login</button>
+    </form>
+</body>
+</html>

--- a/code/paper_logout.php
+++ b/code/paper_logout.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+session_destroy();
+header('Location: paper_login.php');
+exit;
+?>

--- a/sql/create_paper_users_table.sql
+++ b/sql/create_paper_users_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `paper_users` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(100) NOT NULL,
+  `email` varchar(100) NOT NULL UNIQUE,
+  `password` varchar(255) NOT NULL,
+  `logo` varchar(255) DEFAULT NULL,
+  `header` varchar(255) DEFAULT NULL,
+  `activated_on` date DEFAULT NULL,
+  `expires_on` date DEFAULT NULL,
+  `is_active` tinyint(1) NOT NULL DEFAULT 1,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;


### PR DESCRIPTION
## Summary
- Add dedicated login for paper-generation users with activation and logo metadata
- Provide web form to choose subjects, chapters, topics and question counts
- Implement MPDF-based paper generator producing printable PDFs
- Include SQL schema for paper-specific user accounts

## Testing
- `php -l paper_login.php`
- `php -l paper_home.php`
- `php -l paper_logout.php`
- `php -l generate_paper.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba889c78ec832c8804a3347fe4f4cb