### PR TITLE
Add dynamic class-subject-topic selection for paper generation

### DIFF
--- a/code/generate_paper.php
+++ b/code/generate_paper.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 include 'database.php';
 
 $paperName = trim($_POST['paper_name'] ?? 'Question Paper');
+$classId = intval($_POST['class_id'] ?? 0);
 $subjectId = intval($_POST['subject_id'] ?? 0);
 $chapterId = intval($_POST['chapter_id'] ?? 0);
 $topicId = isset($_POST['topic_id']) && $_POST['topic_id'] !== '' ? intval($_POST['topic_id']) : null;


### PR DESCRIPTION
## Summary
- add class dropdown and cascade subject, chapter, topic options on paper generator
- display available question counts per type after topic selection
- provide manual selection button linking to filtered questions

## Testing
- `php -l code/paper_home.php`
- `php -l code/generate_paper.php`


------
https://chatgpt.com/codex/tasks/task_e_68baa0de2214832caf79f79996a55755