### PR TITLE
Handle missing DB connection in paper generator

### DIFF
--- a/code/generate_paper.php
+++ b/code/generate_paper.php
@@ -19,17 +19,18 @@ $fill = intval($_POST['fill'] ?? 0);
 $numerical = intval($_POST['numerical'] ?? 0);
 $paperDate = trim($_POST['paper_date'] ?? '');
 $mode = $_POST['mode'] ?? 'random';
-$logo = $_SESSION['paper_logo'];
-$header = $_SESSION['paper_header'];
+$logo = $_SESSION['paper_logo'] ?? '';
+$header = $_SESSION['paper_header'] ?? '';
 
 function fetch_questions($conn, $table, $fields, $chapterId, $topicId, $limit) {
-    if ($limit <= 0) return [];
+    if ($limit <= 0 || !$conn) return [];
     $sql = "SELECT $fields FROM $table WHERE chapter_id=?";
     $types = 'i';
     $params = [$chapterId];
     if ($topicId) { $sql .= " AND topic_id=?"; $types .= 'i'; $params[] = $topicId; }
     $sql .= " ORDER BY RAND() LIMIT ?"; $types .= 'i'; $params[] = $limit;
     $stmt = $conn->prepare($sql);
+    if (!$stmt) return [];
     $stmt->bind_param($types, ...$params);
     $stmt->execute();
     $res = $stmt->get_result();
@@ -73,7 +74,9 @@ if ($mode === 'manual') {
     $sections['Fill in the Blanks'] = fetch_questions($conn, 'fillintheblanks', 'question', $chapterId, $topicId, $fill);
     $sections['Numerical'] = fetch_questions($conn, 'numericaldb', 'question', $chapterId, $topicId, $numerical);
 }
-$conn->close();
+if ($conn) {
+    $conn->close();
+}
 
 $html = '<div style="text-align:center;">';
 if ($logo) $html .= '<img src="'.htmlspecialchars($logo).'" height="80"><br>';


### PR DESCRIPTION
## Summary
- Guard against undefined session values when generating papers
- Prevent fatal errors when the database connection is unavailable
- Close the database connection only when it exists

## Testing
- `php -l code/generate_paper.php`
- `php -r 'session_start(); $_SESSION["paperloggedin"] = true; $_SESSION["paper_logo"]=""; $_SESSION["paper_header"]="Header"; $_POST["paper_name"]="Test Paper"; $_POST["class_id"] = 1; $_POST["subject_id"] = 1; $_POST["chapter_id"] = 1; $_POST["mcq"] = 1; $_POST["short"] = 1; $_POST["essay"] = 1; $_POST["fill"] = 0; $_POST["numerical"] = 0; include "code/generate_paper.php";' > /tmp/test.pdf`


------
https://chatgpt.com/codex/tasks/task_e_68baa687ceb4832c9727d7755f40a289