### PR TITLE
Allow updating user logo in paper management

### DIFF
--- a/code/paper_manage.php
+++ b/code/paper_manage.php
@@ -17,6 +17,31 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $message = '<p class="text-success">User reactivated successfully!</p>';
         }
         $stmt->close();
+    } elseif (isset($_POST['upload_logo_id'])) {
+        $id = (int)($_POST['upload_logo_id']);
+        $logoPath = null;
+        if (isset($_FILES['logo']) && $_FILES['logo']['error'] === UPLOAD_ERR_OK) {
+            $uploadDir = 'assets/paper_logos/';
+            if (!is_dir($uploadDir)) {
+                mkdir($uploadDir, 0777, true);
+            }
+            $ext = pathinfo($_FILES['logo']['name'], PATHINFO_EXTENSION);
+            $filename = uniqid('logo_', true) . '.' . $ext;
+            $logoPath = $uploadDir . $filename;
+            move_uploaded_file($_FILES['logo']['tmp_name'], $logoPath);
+        }
+        if ($logoPath) {
+            $stmt = $conn->prepare('UPDATE paper_users SET logo = ? WHERE id = ?');
+            $stmt->bind_param('si', $logoPath, $id);
+            if ($stmt->execute()) {
+                $message = '<p class="text-success">Logo updated successfully!</p>';
+            } else {
+                $message = '<p class="text-danger">Error updating logo.</p>';
+            }
+            $stmt->close();
+        } else {
+            $message = '<p class="text-danger">Please select a logo to upload.</p>';
+        }
     } else {
         $name = trim($_POST['name'] ?? '');
         $email = trim($_POST['email'] ?? '');
@@ -53,7 +78,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 $users = [];
-$res = $conn->query('SELECT id, name, email, activated_on, expires_on, is_active FROM paper_users ORDER BY name');
+$res = $conn->query('SELECT id, name, email, logo, activated_on, expires_on, is_active FROM paper_users ORDER BY name');
 if ($res) {
     while ($row = $res->fetch_assoc()) {
         $users[] = $row;
@@ -140,7 +165,16 @@ $conn->close();
               <h4 class="mt-5">Current Paper Users</h4>
               <ul class="list-group">
                 <?php foreach ($users as $row) {
-                    echo '<li class="list-group-item">'.htmlspecialchars($row['name']).' ('.htmlspecialchars($row['email']).')';
+                    echo '<li class="list-group-item">';
+                    if (!empty($row['logo'])) {
+                        echo '<img src="'.htmlspecialchars($row['logo']).'" alt="Logo" height="40" style="margin-right:10px;">';
+                    }
+                    echo htmlspecialchars($row['name']).' ('.htmlspecialchars($row['email']).')';
+                    echo ' <form method="post" enctype="multipart/form-data" style="display:inline-block;margin-left:10px;">';
+                    echo '<input type="hidden" name="upload_logo_id" value="'.intval($row['id']).'">';
+                    echo '<input type="file" name="logo" accept="image/*" required>';
+                    echo '<button type="submit" class="btn btn-link btn-sm">Upload Logo</button>';
+                    echo '</form>';
                     if (!$row['is_active']) {
                         echo ' - Inactive';
                         echo '<form method="post" style="display:inline"><input type="hidden" name="reactivate_id" value="'.intval($row['id']).'"><button type="submit" class="btn btn-link btn-sm">Reactivate</button></form>';


### PR DESCRIPTION
## Summary
- enable uploading or replacing a logo for existing paper users
- show existing logo and upload button within user list on manage page

## Testing
- `php -l code/paper_manage.php`


------
https://chatgpt.com/codex/tasks/task_e_68bafda48d74832ca06f9048b4744ab7