### PR TITLE
Add minimal mPDF stub

### DIFF
--- a/code/lib/Mpdf/Mpdf.php
+++ b/code/lib/Mpdf/Mpdf.php
@@ -1,0 +1,54 @@
+<?php
+namespace Mpdf;
+
+/**
+ * Minimal stub implementation of the mPDF library.
+ * This class provides just enough functionality for
+ * generate_paper.php to create PDFs when the real
+ * mPDF package is not installed.
+ */
+class Mpdf
+{
+    /** @var string Accumulated HTML content */
+    private string $html = '';
+
+    /**
+     * Constructor.
+     *
+     * @param array $config Optional configuration (ignored).
+     */
+    public function __construct(array $config = [])
+    {
+        // Real mPDF supports configuration but this stub ignores it.
+    }
+
+    /**
+     * Append HTML content to the internal buffer.
+     *
+     * @param string $html HTML markup to render.
+     */
+    public function WriteHTML(string $html): void
+    {
+        $this->html .= $html;
+    }
+
+    /**
+     * Output the generated PDF using the underlying FPDF library.
+     *
+     * @param string $filename Output filename.
+     * @param string $dest     Destination mode ('I' for inline).
+     * @return string|null     PDF string when $dest === 'S'.
+     */
+    public function Output(string $filename = '', string $dest = 'I')
+    {
+        if (!class_exists('FPDF')) {
+            require_once __DIR__ . '/../fpdf.php';
+        }
+        $pdf = new \FPDF();
+        $pdf->AddPage();
+        $pdf->SetFont('Helvetica', '', 12);
+        $text = strip_tags($this->html);
+        $pdf->MultiCell(0, 5, $text);
+        return $pdf->Output($filename, $dest);
+    }
+}


### PR DESCRIPTION
## Summary
- add stub mPDF implementation that wraps FPDF so generate_paper.php can run without external dependency

## Testing
- `php -l code/lib/Mpdf/Mpdf.php`
- `php -l code/generate_paper.php`


------
https://chatgpt.com/codex/tasks/task_e_68baff65341c832c8653aabc5b7e0db4