### PR TITLE
style: update paper generator page layout

### DIFF
--- a/code/includes/header.php
+++ b/code/includes/header.php
@@ -11,6 +11,13 @@ if (isset($_SESSION['studentloggedin'])) {
     if (isset($_SESSION['email'])) {
         $userName = $_SESSION['email'];
     }
+} elseif (isset($_SESSION['paperloggedin'])) {
+    $logoutLink = 'paper_logout.php';
+    if (isset($_SESSION['paper_user_name'])) {
+        $userName = $_SESSION['paper_user_name'];
+    } else {
+        $userName = 'Paper User';
+    }
 } else {
     $logoutLink = 'studentlogin.php';
 }
@@ -21,7 +28,7 @@ if (isset($_SESSION['studentloggedin'])) {
         <img src="./assets/img/profile.jpg" alt="Profile">
         <span><?php echo htmlspecialchars($userName); ?></span>
         <a class="logout-btn" href="<?php echo $logoutLink; ?>">
-            <?php echo (isset($_SESSION['studentloggedin']) || isset($_SESSION['instructorloggedin'])) ? 'Logout' : 'Login'; ?>
+            <?php echo (isset($_SESSION['studentloggedin']) || isset($_SESSION['instructorloggedin']) || isset($_SESSION['paperloggedin'])) ? 'Logout' : 'Login'; ?>
         </a>
     </div>
 </header>

--- a/code/includes/sidebar.php
+++ b/code/includes/sidebar.php
@@ -1,5 +1,11 @@
 <?php
-$logout = isset($_SESSION['studentloggedin']) ? 'studentlogout.php' : 'instructorlogout.php';
+if (isset($_SESSION['studentloggedin'])) {
+    $logout = 'studentlogout.php';
+} elseif (isset($_SESSION['paperloggedin'])) {
+    $logout = 'paper_logout.php';
+} else {
+    $logout = 'instructorlogout.php';
+}
 
 // Determine where the "Take Quiz" link should point for students
 $quiz_link = 'quizhome.php';
@@ -45,6 +51,8 @@ if (isset($_SESSION['studentloggedin']) && $_SESSION['studentloggedin'] === true
         <?php if(isset($_SESSION['studentloggedin']) && $_SESSION['studentloggedin'] === true): ?>
             <li><a href="<?php echo $quiz_link; ?>"><i class="fas fa-pencil-alt"></i><span>Take Quiz</span></a></li>
             <li><a href="my_results.php"><i class="fas fa-chart-line"></i><span>My Result</span></a></li>
+        <?php elseif(isset($_SESSION['paperloggedin']) && $_SESSION['paperloggedin'] === true): ?>
+            <li><a href="paper_home.php"><i class="fas fa-file-alt"></i><span>Generate Paper</span></a></li>
         <?php else: ?>
             <li><a href="manage_classes_subjects.php"><i class="fas fa-book"></i><span>Manage Classes &amp; Subjects</span></a></li>
             <li><a href="questionfeed.php"><i class="fas fa-upload"></i><span>Feed Questions</span></a></li>

--- a/code/paper_home.php
+++ b/code/paper_home.php
@@ -5,50 +5,30 @@ if (!isset($_SESSION['paperloggedin']) || $_SESSION['paperloggedin'] !== true) {
     exit;
 }
 include 'database.php';
-$classes = $conn->query("SELECT class_id, class_name FROM classes ORDER BY class_name");
+$classes = $conn->query('SELECT class_id, class_name FROM classes ORDER BY class_name');
 $conn->close();
 $logo = $_SESSION['paper_logo'];
 $header = $_SESSION['paper_header'];
 ?>
 <!DOCTYPE html>
-<html lang="en">
+<html lang='en'>
 <head>
-    <meta charset="utf-8" />
-    <link rel="apple-touch-icon" sizes="76x76" href="./assets/img/apple-icon.png">
-    <link rel="icon" type="image/png" href="./assets/img/favicon.png">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta charset='utf-8' />
+    <link rel='apple-touch-icon' sizes='76x76' href='./assets/img/apple-icon.png'>
+    <link rel='icon' type='image/png' href='./assets/img/favicon.png'>
+    <meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1' />
     <title>Generate Paper</title>
     <meta content='width=device-width, initial-scale=1.0, shrink-to-fit=no' name='viewport' />
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Roboto+Slab:400,700|Material+Icons" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link href="./assets/css/material-kit.css?v=2.0.4" rel="stylesheet" />
-    <link href="./assets/css/modern.css" rel="stylesheet" />
+    <link rel='stylesheet' type='text/css' href='https://fonts.googleapis.com/css?family=Inter:300,400,500,700|Material+Icons' />
+    <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css'>
+    <link href='./assets/css/material-kit.css?v=2.0.4' rel='stylesheet' />
+    <link href='./assets/css/sidebar.css' rel='stylesheet' />
+    <link href='./assets/css/modern.css' rel='stylesheet' />
+    <link href='./assets/css/navbar.css' rel='stylesheet' />
+    <link href='./assets/css/portal.css' rel='stylesheet' />
+    <link href='./assets/css/manage.css' rel='stylesheet' />
+    <link id='dark-mode-style' rel='stylesheet' href='./assets/css/dark-mode.css' />
     <style>
-        html, body { height: 100%; }
-        body { display: flex; flex-direction: column; min-height: 100vh; margin: 0; }
-        .page-header {
-            background: linear-gradient(45deg, rgba(0,0,0,0.7), rgba(72,72,176,0.7)),
-                        url('./assets/img/bg.jpg') center center;
-            background-size: cover;
-            margin: 0;
-            padding: 0;
-            border: 0;
-            display: flex;
-            align-items: flex-start;
-            justify-content: center;
-            flex: 1 0 auto;
-        }
-        .card { margin-top: 20px; }
-        .card .card-header-primary {
-            background: linear-gradient(60deg, #ab47bc, #8e24aa);
-            box-shadow: 0 5px 20px 0px rgba(0, 0, 0, 0.2),
-                       0 13px 24px -11px rgba(156, 39, 176, 0.6);
-            margin: -20px 20px 15px;
-            border-radius: 3px;
-            padding: 15px;
-        }
-        .card-header-primary .card-title { color: #fff; margin: 0; }
-        .btn { width: 100%; }
         #question-modal {
             position: fixed;
             top: 0;
@@ -73,121 +53,143 @@ $header = $_SESSION['paper_header'];
         #question-lists .type-block h5 { margin-top: 0; }
     </style>
 </head>
-<body>
-    <div class="page-header header-filter">
-        <div class="container">
+<body class='dark-mode'>
+<div class='layout'>
+  <?php include './includes/sidebar.php'; ?>
+  <div class='main'>
+    <?php include './includes/header.php'; ?>
+    <main class='content'>
+      <div class='wrapper'>
+        <div class='main main-raised'>
+          <div class='container'>
             <?php if ($logo) { echo '<div class="text-center"><img src="' . htmlspecialchars($logo) . '" height="80"></div>'; } ?>
-            <h2 class="text-center text-white"><?php echo htmlspecialchars($header); ?></h2>
-            <div class="row">
-                <div class="col-md-6 ml-auto mr-auto">
-                    <div class="card">
-                        <form method="post" action="generate_paper.php">
-                            <div class="card-header card-header-primary text-center">
-                                <h4 class="card-title">Generate Paper</h4>
-                            </div>
-                            <div class="card-body">
-                                <div class="form-group">
-                                    <label class="bmd-label-floating">Paper Name</label>
-                                    <input type="text" name="paper_name" class="form-control" required>
-                                </div>
-                                <div class="form-group">
-                                    <label class="bmd-label-floating">Select Class</label>
-                                    <select name="class_id" id="class_id" class="form-control" required>
-                                        <option value="">Select Class</option>
-                                        <?php while($row = $classes->fetch_assoc()) { echo '<option value="'.$row['class_id'].'">'.htmlspecialchars($row['class_name']).'</option>'; } ?>
-                                    </select>
-                                </div>
-                                <div class="form-group">
-                                    <label class="bmd-label-floating">Select Subject</label>
-                                    <select name="subject_id" id="subject_id" class="form-control" required>
-                                        <option value="">Select Subject</option>
-                                    </select>
-                                </div>
-                                <div class="form-group">
-                                    <label class="bmd-label-floating">Select Chapter</label>
-                                    <select name="chapter_id" id="chapter_id" class="form-control" required>
-                                        <option value="">Select Chapter</option>
-                                    </select>
-                                </div>
-                                <div class="form-group">
-                                    <label class="bmd-label-floating">Select Topic</label>
-                                    <select name="topic_id" id="topic_id" class="form-control">
-                                        <option value="">Select Topic</option>
-                                    </select>
-                                </div>
-                                <div class="form-group">
-                                    <label class="bmd-label-floating">MCQs</label>
-                                    <input type="number" name="mcq" value="0" min="0" class="form-control">
-                                    <small class="form-text text-muted">Available: <span id="mcq-count">0</span></small>
-                                </div>
-                                <div class="form-group">
-                                    <label class="bmd-label-floating">Short Questions</label>
-                                    <input type="number" name="short" value="0" min="0" class="form-control">
-                                    <small class="form-text text-muted">Available: <span id="short-count">0</span></small>
-                                </div>
-                                <div class="form-group">
-                                    <label class="bmd-label-floating">Long Questions</label>
-                                    <input type="number" name="essay" value="0" min="0" class="form-control">
-                                    <small class="form-text text-muted">Available: <span id="essay-count">0</span></small>
-                                </div>
-                                <div class="form-group">
-                                    <label class="bmd-label-floating">Fill in the Blanks</label>
-                                    <input type="number" name="fill" value="0" min="0" class="form-control">
-                                    <small class="form-text text-muted">Available: <span id="fill-count">0</span></small>
-                                </div>
-                                <div class="form-group">
-                                    <label class="bmd-label-floating">Numerical</label>
-                                    <input type="number" name="numerical" value="0" min="0" class="form-control">
-                                    <small class="form-text text-muted">Available: <span id="numerical-count">0</span></small>
-                                </div>
-                                <div class="form-group" id="manual-select-wrapper" style="display:none;">
-                                    <button type="button" id="manual-select" class="btn btn-secondary">Manual Selection</button>
-                                </div>
-                                <input type="hidden" name="selected_mcq" id="selected_mcq">
-                                <input type="hidden" name="selected_short" id="selected_short">
-                                <input type="hidden" name="selected_essay" id="selected_essay">
-                                <input type="hidden" name="selected_fill" id="selected_fill">
-                                <input type="hidden" name="selected_numerical" id="selected_numerical">
-                                <div class="form-group">
-                                    <label class="bmd-label-floating">Date (optional)</label>
-                                    <input type="date" name="paper_date" class="form-control">
-                                </div>
-                                <div class="form-group">
-                                    <label>Selection Mode</label><br>
-                                    <div class="form-check form-check-inline">
-                                        <label class="form-check-label">
-                                            <input class="form-check-input" type="radio" name="mode" value="random" checked> Random
-                                            <span class="circle"><span class="check"></span></span>
-                                        </label>
-                                    </div>
-                                    <div class="form-check form-check-inline">
-                                        <label class="form-check-label">
-                                            <input class="form-check-input" type="radio" name="mode" value="manual"> Manual
-                                            <span class="circle"><span class="check"></span></span>
-                                        </label>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="footer text-center">
-                                <button type="submit" class="btn btn-primary btn-lg">Generate Paper</button>
-                                <a href="paper_logout.php" class="btn btn-default btn-lg">Logout</a>
-                            </div>
-                        </form>
+            <h2 class='text-center text-white'><?php echo htmlspecialchars($header); ?></h2>
+            <div class='row'>
+              <div class='col-md-6 ml-auto mr-auto'>
+                <div class='card'>
+                  <form method='post' action='generate_paper.php'>
+                    <div class='card-header card-header-primary text-center'>
+                      <h4 class='card-title'>Generate Paper</h4>
                     </div>
+                    <div class='card-body'>
+                      <div class='form-group'>
+                        <label class='bmd-label-floating'>Paper Name</label>
+                        <input type='text' name='paper_name' class='form-control' required>
+                      </div>
+                      <div class='form-group'>
+                        <label class='bmd-label-floating'>Select Class</label>
+                        <select name='class_id' id='class_id' class='form-control' required>
+                          <option value=''>Select Class</option>
+                          <?php while($row = $classes->fetch_assoc()) { echo '<option value=\''.$row['class_id'].'\'>'.htmlspecialchars($row['class_name']).'</option>'; } ?>
+                        </select>
+                      </div>
+                      <div class='form-group'>
+                        <label class='bmd-label-floating'>Select Subject</label>
+                        <select name='subject_id' id='subject_id' class='form-control' required>
+                          <option value=''>Select Subject</option>
+                        </select>
+                      </div>
+                      <div class='form-group'>
+                        <label class='bmd-label-floating'>Select Chapter</label>
+                        <select name='chapter_id' id='chapter_id' class='form-control' required>
+                          <option value=''>Select Chapter</option>
+                        </select>
+                      </div>
+                      <div class='form-group'>
+                        <label class='bmd-label-floating'>Select Topic</label>
+                        <select name='topic_id' id='topic_id' class='form-control'>
+                          <option value=''>Select Topic</option>
+                        </select>
+                      </div>
+                      <div class='form-group'>
+                        <label class='bmd-label-floating'>MCQs</label>
+                        <input type='number' name='mcq' value='0' min='0' class='form-control'>
+                        <small class='form-text text-muted'>Available: <span id='mcq-count'>0</span></small>
+                      </div>
+                      <div class='form-group'>
+                        <label class='bmd-label-floating'>Short Questions</label>
+                        <input type='number' name='short' value='0' min='0' class='form-control'>
+                        <small class='form-text text-muted'>Available: <span id='short-count'>0</span></small>
+                      </div>
+                      <div class='form-group'>
+                        <label class='bmd-label-floating'>Long Questions</label>
+                        <input type='number' name='essay' value='0' min='0' class='form-control'>
+                        <small class='form-text text-muted'>Available: <span id='essay-count'>0</span></small>
+                      </div>
+                      <div class='form-group'>
+                        <label class='bmd-label-floating'>Fill in the Blanks</label>
+                        <input type='number' name='fill' value='0' min='0' class='form-control'>
+                        <small class='form-text text-muted'>Available: <span id='fill-count'>0</span></small>
+                      </div>
+                      <div class='form-group'>
+                        <label class='bmd-label-floating'>Numerical</label>
+                        <input type='number' name='numerical' value='0' min='0' class='form-control'>
+                        <small class='form-text text-muted'>Available: <span id='numerical-count'>0</span></small>
+                      </div>
+                      <div class='form-group' id='manual-select-wrapper' style='display:none;'>
+                        <button type='button' id='manual-select' class='btn btn-secondary'>Manual Selection</button>
+                      </div>
+                      <input type='hidden' name='selected_mcq' id='selected_mcq'>
+                      <input type='hidden' name='selected_short' id='selected_short'>
+                      <input type='hidden' name='selected_essay' id='selected_essay'>
+                      <input type='hidden' name='selected_fill' id='selected_fill'>
+                      <input type='hidden' name='selected_numerical' id='selected_numerical'>
+                      <div class='form-group'>
+                        <label class='bmd-label-floating'>Date (optional)</label>
+                        <input type='date' name='paper_date' class='form-control'>
+                      </div>
+                      <div class='form-group'>
+                        <label>Selection Mode</label><br>
+                        <div class='form-check form-check-inline'>
+                          <label class='form-check-label'>
+                            <input class='form-check-input' type='radio' name='mode' value='random' checked> Random
+                            <span class='circle'><span class='check'></span></span>
+                          </label>
+                        </div>
+                        <div class='form-check form-check-inline'>
+                          <label class='form-check-label'>
+                            <input class='form-check-input' type='radio' name='mode' value='manual'> Manual
+                            <span class='circle'><span class='check'></span></span>
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                    <div class='footer text-center'>
+                      <button type='submit' class='btn btn-primary btn-lg'>Generate Paper</button>
+                    </div>
+                  </form>
                 </div>
+              </div>
             </div>
+          </div>
+        </div>
+      </div>
+    </main>
+    <footer class='footer-text'>
+      <p>Narowal Public School and College</p>
+      <p>Developed and Maintained by Sir Hassan Tariq</p>
+    </footer>
+  </div>
+</div>
+
+<div id='question-modal'>
+    <div class='modal-content'>
+        <h4>Select Questions</h4>
+        <div id='question-lists'></div>
+        <div class='text-right'>
+            <button type='button' id='save-selection' class='btn btn-primary btn-sm'>Save</button>
+            <button type='button' id='cancel-selection' class='btn btn-secondary btn-sm'>Cancel</button>
         </div>
     </div>
-    <div id="question-modal">
-        <div class="modal-content">
-            <h4>Select Questions</h4>
-            <div id="question-lists"></div>
-            <div class="text-right">
-                <button type="button" id="save-selection" class="btn btn-primary btn-sm">Save</button>
-                <button type="button" id="cancel-selection" class="btn btn-secondary btn-sm">Cancel</button>
-            </div>
-        </div>
-    </div>
+</div>
+
+<script src='./assets/js/core/jquery.min.js' type='text/javascript'></script>
+<script src='./assets/js/core/popper.min.js' type='text/javascript'></script>
+<script src='./assets/js/core/bootstrap-material-design.min.js' type='text/javascript'></script>
+<script src='./assets/js/plugins/moment.min.js'></script>
+<script src='./assets/js/material-kit.js?v=2.0.4' type='text/javascript'></script>
+<script src='./assets/js/dark-mode.js'></script>
+<script src='./assets/js/sidebar.js'></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     const classSelect = document.getElementById('class_id');
@@ -217,15 +219,15 @@ document.addEventListener('DOMContentLoaded', function() {
 
     classSelect.addEventListener('change', function() {
         const classId = this.value;
-        subjectSelect.innerHTML = '<option value="">Select Subject</option>';
-        chapterSelect.innerHTML = '<option value="">Select Chapter</option>';
-        topicSelect.innerHTML = '<option value="">Select Topic</option>';
+        subjectSelect.innerHTML = `<option value=''>Select Subject</option>`;
+        chapterSelect.innerHTML = `<option value=''>Select Chapter</option>`;
+        topicSelect.innerHTML = `<option value=''>Select Topic</option>`;
         if (!classId) return;
         fetch('get_subjects.php?class_id=' + classId)
             .then(r => r.json())
             .then(data => {
                 data.forEach(s => {
-                    subjectSelect.insertAdjacentHTML('beforeend', `<option value="${s.subject_id}">${s.subject_name}</option>`);
+                    subjectSelect.insertAdjacentHTML('beforeend', `<option value='${s.subject_id}'>${s.subject_name}</option>`);
                 });
             });
     });
@@ -233,15 +235,15 @@ document.addEventListener('DOMContentLoaded', function() {
     subjectSelect.addEventListener('change', function() {
         const classId = classSelect.value;
         const subjectId = this.value;
-        chapterSelect.innerHTML = '<option value="">Select Chapter</option>';
-        topicSelect.innerHTML = '<option value="">Select Topic</option>';
+        chapterSelect.innerHTML = `<option value=''>Select Chapter</option>`;
+        topicSelect.innerHTML = `<option value=''>Select Topic</option>`;
         if (!classId || !subjectId) return;
         fetch(`get_chapters.php?class_id=${classId}&subject_id=${subjectId}`)
             .then(r => r.json())
             .then(data => {
                 if (Array.isArray(data)) {
                     data.forEach(c => {
-                        chapterSelect.insertAdjacentHTML('beforeend', `<option value="${c.chapter_id}">${c.chapter_name}</option>`);
+                        chapterSelect.insertAdjacentHTML('beforeend', `<option value='${c.chapter_id}'>${c.chapter_name}</option>`);
                     });
                 }
             });
@@ -249,13 +251,13 @@ document.addEventListener('DOMContentLoaded', function() {
 
     chapterSelect.addEventListener('change', function() {
         const chapterId = this.value;
-        topicSelect.innerHTML = '<option value="">Select Topic</option>';
+        topicSelect.innerHTML = `<option value=''>Select Topic</option>`;
         if (!chapterId) return;
         fetch('get_topics.php?chapter_id=' + chapterId)
             .then(r => r.json())
             .then(data => {
                 data.forEach(t => {
-                    topicSelect.insertAdjacentHTML('beforeend', `<option value="${t.topic_id}">${t.topic_name}</option>`);
+                    topicSelect.insertAdjacentHTML('beforeend', `<option value='${t.topic_id}'>${t.topic_name}</option>`);
                 });
             });
     });
@@ -288,7 +290,7 @@ document.addEventListener('DOMContentLoaded', function() {
         typeMap.forEach(t => {
             const block = document.createElement('div');
             block.className = 'type-block';
-            block.innerHTML = `<h5>${t.label}</h5><div class="questions">Loading...</div>`;
+            block.innerHTML = `<h5>${t.label}</h5><div class='questions'>Loading...</div>`;
             questionLists.appendChild(block);
             const params = new URLSearchParams();
             params.append('type', t.key);
@@ -305,7 +307,7 @@ document.addEventListener('DOMContentLoaded', function() {
                             const id = q.id;
                             const numeric = id.split('_')[1];
                             const checked = selected.includes(numeric) ? 'checked' : '';
-                            qDiv.insertAdjacentHTML('beforeend', `<div><label><input type="checkbox" data-type="${t.key}" value="${id}" ${checked}> ${q.question}</label></div>`);
+                            qDiv.insertAdjacentHTML('beforeend', `<div><label><input type='checkbox' data-type='${t.key}' value='${id}' ${checked}> ${q.question}</label></div>`);
                         });
                     } else {
                         qDiv.textContent = 'No questions available.';
@@ -321,9 +323,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
     saveSelection.addEventListener('click', function() {
         typeMap.forEach(t => {
-            const selected = Array.from(questionLists.querySelectorAll(`input[data-type="${t.key}"]:checked`)).map(cb => cb.value.split('_')[1]);
+            const selected = Array.from(questionLists.querySelectorAll(`input[data-type='${t.key}']:checked`)).map(cb => cb.value.split('_')[1]);
             document.getElementById(t.hidden).value = selected.join(',');
-            const inputField = document.querySelector(`input[name="${t.input}"]`);
+            const inputField = document.querySelector(`input[name='${t.input}']`);
             if (inputField) inputField.value = selected.length;
         });
         questionModal.style.display = 'none';
@@ -332,3 +334,4 @@ document.addEventListener('DOMContentLoaded', function() {
 </script>
 </body>
 </html>
+

--- a/code/paper_login.php
+++ b/code/paper_login.php
@@ -33,6 +33,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $_SESSION['paper_user_id'] = $user['id'];
                     $_SESSION['paper_logo'] = $user['logo'];
                     $_SESSION['paper_header'] = $user['header'];
+                    $_SESSION['paper_user_name'] = $user['name'];
                     header('Location: paper_home.php');
                     exit;
                 }


### PR DESCRIPTION
## Summary
- refactor paper generation page to use website layout with shared sidebar/header
- support paper users in shared header and sidebar, including logout handling
- preserve paper user name during login for display in header

## Testing
- `php -l code/paper_home.php`
- `php -l code/includes/header.php`
- `php -l code/includes/sidebar.php`
- `php -l code/paper_login.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb10525798832c8f084694db5971a2