### PR TITLE
Load bundled mPDF library for paper generation

### DIFF
--- a/code/generate_paper.php
+++ b/code/generate_paper.php
@@ -6,7 +6,7 @@ if (!isset($_SESSION['paperloggedin']) || $_SESSION['paperloggedin'] !== true) {
     exit;
 }
 
-require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/lib/mpdf/vendor/autoload.php';
 
 include 'database.php';
 


### PR DESCRIPTION
## Summary
- use bundled mPDF autoloader instead of Composer autoload for PDF generation

## Testing
- `php -l code/generate_paper.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb1f5a3af8832c8f2c8f155379bf8a