### PR TITLE
Stay on student home before quiz start

### DIFF
--- a/code/includes/sidebar.php
+++ b/code/includes/sidebar.php
@@ -2,7 +2,8 @@
 $logout = isset($_SESSION['studentloggedin']) ? 'studentlogout.php' : 'instructorlogout.php';
 
 // Determine where the "Take Quiz" link should point for students
-$quiz_link = 'quizhome.php';
+// Default to student home so users stay on the same page when no quiz is active
+$quiz_link = 'studenthome.php';
 if (isset($_SESSION['studentloggedin']) && $_SESSION['studentloggedin'] === true) {
     // Check if an active quiz is available for the logged-in student
     include_once __DIR__ . '/../database.php';

--- a/code/quizhome.php
+++ b/code/quizhome.php
@@ -35,7 +35,7 @@ if (isset($_SESSION['studentloggedin']) && $_SESSION['studentloggedin'] === true
 
     if ($class_id && $rollnumber) {
         $quiz_sql = "SELECT quizid FROM quizconfig
-                     WHERE endtime >= NOW()
+                     WHERE starttime <= NOW() AND endtime >= NOW()
                        AND class_id = ?
                        AND (section IS NULL OR LOWER(section) = LOWER(?))
                        AND (
@@ -43,7 +43,7 @@ if (isset($_SESSION['studentloggedin']) && $_SESSION['studentloggedin'] === true
                            WHERE qr.quizid = quizconfig.quizid
                              AND qr.rollnumber = ?
                        ) < attempts
-                     LIMIT 1";
+                    LIMIT 1";
         $stmt_quiz = $conn->prepare($quiz_sql);
         $section_param = $section ? $section : '';
         $stmt_quiz->bind_param('isi', $class_id, $section_param, $rollnumber);

--- a/code/studenthome.php
+++ b/code/studenthome.php
@@ -146,6 +146,10 @@
     <?php include './includes/header.php'; ?>
     <main class="content">
       <h1>Welcome to the Student Portal</h1>
+      <?php if (isset($_SESSION['no_quiz_message'])): ?>
+        <p class="upcoming-quiz"><?php echo htmlspecialchars($_SESSION['no_quiz_message']); ?></p>
+        <?php unset($_SESSION['no_quiz_message']); ?>
+      <?php endif; ?>
       <?php if ($upcoming_quiz): ?>
         <p class="upcoming-quiz">Upcoming quiz: <strong><?php echo htmlspecialchars($upcoming_quiz['quizname']); ?></strong> on <?php echo htmlspecialchars($upcoming_quiz['starttime']); ?></p>
       <?php else: ?>


### PR DESCRIPTION
## Summary
- Keep "Take Quiz" link on student home when no quiz is active
- Guard quiz home with start time check and redirect back to student home
- Display server message on student home after redirection

## Testing
- `php -l code/includes/sidebar.php`
- `php -l code/quizhome.php`
- `php -l code/studenthome.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbe2967eec832ca2e1e39fd67bbca8